### PR TITLE
s/MiniTest::Unit::TestCase/MiniTest::Test/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,6 @@ Please do not add a README or README.md file to the problem directory. The
 READMEs are constructed using shared metadata, which lives in the
 [exercism/x-common](https://github.com/exercism/x-common) repository.
 
-## Minitest vs MiniTest
-
-Minitest v4.x (`MiniTest::Unit::TestCase`) ships with the language, whereas
-Minitest v5.x (`Minitest::Test`) does not. This means that people who have
-installed v5.x will get deprecation warnings.
-
-There's no really good way around this at the moment. We can't upgrade without
-forcing people to install an extra dependency.
-
 ## Contributing Guide
 
 For an in-depth discussion of how exercism language tracks and problem sets

--- a/accumulate/accumulate_test.rb
+++ b/accumulate/accumulate_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'array'
 
-class ArrayTest < MiniTest::Unit::TestCase
+class ArrayTest < Minitest::Test
   def test_empty_accumulation
     assert_equal [], [].accumulate { |e| e * e }
   end

--- a/allergies/allergies_test.rb
+++ b/allergies/allergies_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'allergies'
 
-class AllergiesTest < MiniTest::Unit::TestCase
+class AllergiesTest < Minitest::Test
   def test_no_allergies_means_not_allergic
     allergies = Allergies.new(0)
     refute allergies.allergic_to?('peanuts')

--- a/anagram/anagram_test.rb
+++ b/anagram/anagram_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'anagram'
 
-class AnagramTest < MiniTest::Unit::TestCase
+class AnagramTest < Minitest::Test
   def test_no_matches
     detector = Anagram.new('diaper')
     assert_equal [], detector.match(%w(hello world zombies pants))

--- a/atbash-cipher/atbash_cipher_test.rb
+++ b/atbash-cipher/atbash_cipher_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require_relative 'atbash'
 
 # rubocop:disable Style/MethodName
-class AtbashTest < MiniTest::Unit::TestCase
+class AtbashTest < Minitest::Test
   def test_encode_no
     assert_equal 'ml', Atbash.encode('no')
   end

--- a/beer-song/beer_song_test.rb
+++ b/beer-song/beer_song_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'beer_song'
 
-class BeerSongTest < MiniTest::Unit::TestCase
+class BeerSongTest < Minitest::Test
   def song
     @song = ::BeerSong.new
   end

--- a/binary-search-tree/binary_search_tree_test.rb
+++ b/binary-search-tree/binary_search_tree_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'bst'
 
-class BstTest < MiniTest::Unit::TestCase
+class BstTest < Minitest::Test
   def test_data_is_retained
     assert_equal 4, Bst.new(4).data
   end

--- a/binary-search/binary_search_test.rb
+++ b/binary-search/binary_search_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'binary'
 
-class BinarySearchTest < MiniTest::Unit::TestCase
+class BinarySearchTest < Minitest::Test
   def test_it_has_list_data
     binary = BinarySearch.new([1, 3, 4, 6, 8, 9, 11])
     assert_equal [1, 3, 4, 6, 8, 9, 11], binary.list

--- a/binary/binary_test.rb
+++ b/binary/binary_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'binary'
 
-class BinaryTest < MiniTest::Unit::TestCase
+class BinaryTest < Minitest::Test
   def test_binary_1_is_decimal_1
     assert_equal 1, Binary.new('1').to_decimal
   end

--- a/bob/bob_test.rb
+++ b/bob/bob_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'bob'
 
-class BobTest < MiniTest::Unit::TestCase
+class BobTest < Minitest::Test
   def bob
     ::Bob.new
   end

--- a/circular-buffer/circular_buffer_test.rb
+++ b/circular-buffer/circular_buffer_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'circular_buffer'
 
-class CircularBufferTest < MiniTest::Unit::TestCase
+class CircularBufferTest < Minitest::Test
   def test_read_empty_buffer_throws_buffer_empty_exception
     buffer = CircularBuffer.new(1)
     assert_raises(CircularBuffer::BufferEmptyException) { buffer.read }

--- a/clock/clock_test.rb
+++ b/clock/clock_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'clock'
 
-class ClockTest < MiniTest::Unit::TestCase
+class ClockTest < Minitest::Test
   def test_on_the_hour
     assert_equal '08:00', Clock.at(8).to_s
     assert_equal '09:00', Clock.at(9).to_s

--- a/crypto-square/crypto_square_test.rb
+++ b/crypto-square/crypto_square_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'crypto'
 
-class CryptoTest < MiniTest::Unit::TestCase
+class CryptoTest < Minitest::Test
   def test_normalize_strange_characters
     crypto = Crypto.new('s#$%^&plunk')
     assert_equal 'splunk', crypto.normalize_plaintext

--- a/custom-set/custom_set_test.rb
+++ b/custom-set/custom_set_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'custom_set'
 
-class CustomSetTest < MiniTest::Unit::TestCase
+class CustomSetTest < Minitest::Test
   def test_equal
     assert_equal CustomSet.new([1, 3]), CustomSet.new([3, 1])
   end

--- a/difference-of-squares/difference_of_squares_test.rb
+++ b/difference-of-squares/difference_of_squares_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'squares'
 
-class SquaresTest < MiniTest::Unit::TestCase
+class SquaresTest < Minitest::Test
   def test_square_of_sums_to_5
     assert_equal 225, Squares.new(5).square_of_sums
   end

--- a/etl/etl_test.rb
+++ b/etl/etl_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'etl'
 
-class TransformTest < MiniTest::Unit::TestCase
+class TransformTest < Minitest::Test
   def test_transform_one_value
     old = { 1 => ['A'] }
     expected = { 'a' => 1 }

--- a/food-chain/food_chain_test.rb
+++ b/food-chain/food_chain_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require_relative 'food_chain'
 
 # rubocop:disable Metrics/MethodLength, Metrics/LineLength
-class FoodChainTest < MiniTest::Unit::TestCase
+class FoodChainTest < Minitest::Test
   attr_reader :song
   def song
     @song = ::FoodChainSong.new

--- a/gigasecond/gigasecond_test.rb
+++ b/gigasecond/gigasecond_test.rb
@@ -3,7 +3,7 @@ require 'date'
 require 'time'
 
 require_relative 'gigasecond'
-class GigasecondTest < MiniTest::Unit::TestCase
+class GigasecondTest < Minitest::Test
   def test_1
     gs = Gigasecond.from(Time.utc(2011, 4, 25))
     assert_equal Time.utc(2043, 1, 1, 1, 46, 40), gs

--- a/grade-school/grade_school_test.rb
+++ b/grade-school/grade_school_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'school'
 
-class SchoolTest < MiniTest::Unit::TestCase
+class SchoolTest < Minitest::Test
   attr_reader :school
 
   def setup

--- a/grains/grains_test.rb
+++ b/grains/grains_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'grains'
 
-class GrainsTest < MiniTest::Unit::TestCase
+class GrainsTest < Minitest::Test
   def test_square_1
     assert_equal 1, Grains.new.square(1)
   end

--- a/hamming/hamming_test.rb
+++ b/hamming/hamming_test.rb
@@ -7,7 +7,7 @@ rescue LoadError => e
   exit 1
 end
 
-class HammingTest < MiniTest::Unit::TestCase
+class HammingTest < Minitest::Test
   def test_no_difference_between_identical_strands
     assert_equal 0, Hamming.compute('A', 'A')
   end

--- a/hexadecimal/hexadecimal_test.rb
+++ b/hexadecimal/hexadecimal_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'hexadecimal'
 
-class HexadecimalTest < MiniTest::Unit::TestCase
+class HexadecimalTest < Minitest::Test
   def test_hex_1_is_decimal_1
     assert_equal 1, Hexadecimal.new('1').to_decimal
   end

--- a/house/house_test.rb
+++ b/house/house_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require_relative 'house'
 
 # rubocop:disable Metrics/MethodLength
-class HouseTest < MiniTest::Unit::TestCase
+class HouseTest < Minitest::Test
   def test_rhyme
     expected = <<-RHYME
 This is the house that Jack built.

--- a/kindergarten-garden/kindergarten_garden_test.rb
+++ b/kindergarten-garden/kindergarten_garden_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'garden'
 
-class GardenTest < MiniTest::Unit::TestCase
+class GardenTest < Minitest::Test
   def test_alices_garden
     garden = Garden.new("RC\nGG")
     assert_equal [:radishes, :clover, :grass, :grass], garden.alice
@@ -27,7 +27,7 @@ class GardenTest < MiniTest::Unit::TestCase
   end
 end
 
-class TestFullGarden < MiniTest::Unit::TestCase
+class TestFullGarden < Minitest::Test
   def setup
     skip
     diagram = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
@@ -97,7 +97,7 @@ class TestFullGarden < MiniTest::Unit::TestCase
   end
 end
 
-class DisorderedTest < MiniTest::Unit::TestCase
+class DisorderedTest < Minitest::Test
   def setup
     skip
     diagram = "VCRRGVRG\nRVGCCGCV"
@@ -128,7 +128,7 @@ class DisorderedTest < MiniTest::Unit::TestCase
   end
 end
 
-class TwoGardensDifferentStudents < MiniTest::Unit::TestCase
+class TwoGardensDifferentStudents < Minitest::Test
   def diagram
     "VCRRGVRG\nRVGCCGCV"
   end

--- a/largest-series-product/largest_series_product_test.rb
+++ b/largest-series-product/largest_series_product_test.rb
@@ -4,7 +4,7 @@ require_relative 'series'
 # Rubocop directives
 # rubocop:disable Lint/ParenthesesAsGroupedExpression
 #
-class Seriestest < MiniTest::Unit::TestCase
+class Seriestest < Minitest::Test
   def test_digits
     assert_equal (0..9).to_a, Series.new('0123456789').digits
   end

--- a/leap/leap_test.rb
+++ b/leap/leap_test.rb
@@ -11,7 +11,7 @@ class Date
   alias_method :julian_leap?, :leap?
 end
 
-class YearTest < MiniTest::Unit::TestCase
+class YearTest < Minitest::Test
   def test_leap_year
     assert Year.leap?(1996), 'Yes, 1996 is a leap year'
   end

--- a/linked-list/linked_list_test.rb
+++ b/linked-list/linked_list_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'linked_list'
 
-class DequeTest < MiniTest::Unit::TestCase
+class DequeTest < Minitest::Test
   def test_push_pop
     deque = Deque.new
     deque.push(10)

--- a/luhn/luhn_test.rb
+++ b/luhn/luhn_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'luhn'
 
-class LuhnTest < MiniTest::Unit::TestCase
+class LuhnTest < Minitest::Test
   def test_addends
     luhn = Luhn.new(12_121)
     assert_equal [1, 4, 1, 4, 1], luhn.addends

--- a/matrix/matrix_test.rb
+++ b/matrix/matrix_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'matrix'
 
-class MatrixTest < MiniTest::Unit::TestCase
+class MatrixTest < Minitest::Test
   def test_extract_a_row
     matrix = Matrix.new("1 2\n10 20")
     assert_equal [1, 2], matrix.rows[0]

--- a/meetup/meetup_test.rb
+++ b/meetup/meetup_test.rb
@@ -7,7 +7,7 @@ require_relative 'meetup'
 # where weekday is one of :monday, :tuesday, etc
 # and schedule is :first, :second, :third, :fourth, :last or :teenth.
 # rubocop:disable Style/AlignParameters
-class MeetupTest < MiniTest::Unit::TestCase
+class MeetupTest < Minitest::Test
   def test_monteenth_of_may_2013
     assert_equal Date.new(2013, 5, 13),
       Meetup.new(5, 2013).day(:monday, :teenth)

--- a/minesweeper/minesweeper_test.rb
+++ b/minesweeper/minesweeper_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'minesweeper.rb'
 
-class MinesweeperTest < MiniTest::Unit::TestCase
+class MinesweeperTest < Minitest::Test
   def test_transform1
     inp = ['+------+', '| *  * |', '|  *   |', '|    * |', '|   * *|',
            '| *  * |', '|      |', '+------+']

--- a/nth-prime/nth_prime_test.rb
+++ b/nth-prime/nth_prime_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'prime'
 
-class TestPrimes < MiniTest::Unit::TestCase
+class TestPrimes < Minitest::Test
   def test_first
     assert_equal 2, Prime.nth(1)
   end

--- a/nucleotide-count/nucleotide_test.rb
+++ b/nucleotide-count/nucleotide_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'nucleotide'
 
-class NucleotideTest < MiniTest::Unit::TestCase
+class NucleotideTest < Minitest::Test
   def test_empty_dna_strand_has_no_adenosine
     assert_equal 0, Nucleotide.from_dna('').count('A')
   end

--- a/ocr-numbers/ocr_numbers_test.rb
+++ b/ocr-numbers/ocr_numbers_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'ocr'
 
-class OCRTest < MiniTest::Unit::TestCase
+class OCRTest < Minitest::Test
   def test_recognize_zero
     text = <<-NUMBER.chomp
  _

--- a/octal/octal_test.rb
+++ b/octal/octal_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'octal'
 
-class OctalTest < MiniTest::Unit::TestCase
+class OctalTest < Minitest::Test
   def test_octal_1_is_decimal_1
     assert_equal 1, Octal.new('1').to_decimal
   end

--- a/palindrome-products/palindrome_products_test.rb
+++ b/palindrome-products/palindrome_products_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'palindromes'
 
-class PalindromesTest < MiniTest::Unit::TestCase
+class PalindromesTest < Minitest::Test
   def test_largest_palindrome_from_single_digit_factors
     palindromes = Palindromes.new(max_factor: 9)
     palindromes.generate

--- a/pascals-triangle/pascals_triangle_test.rb
+++ b/pascals-triangle/pascals_triangle_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'triangle'
 
-class TriangleTest < MiniTest::Unit::TestCase
+class TriangleTest < Minitest::Test
   def test_one_row
     triangle = Triangle.new(1)
     assert_equal [[1]], triangle.rows

--- a/phone-number/phone_number_test.rb
+++ b/phone-number/phone_number_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'phone_number'
 
-class PhoneNumberTest < MiniTest::Unit::TestCase
+class PhoneNumberTest < Minitest::Test
   def test_cleans_number
     number = PhoneNumber.new('(123) 456-7890').number
     assert_equal '1234567890', number

--- a/pig-latin/pig_latin_test.rb
+++ b/pig-latin/pig_latin_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'pig_latin'
 
-class PigLatinTest < MiniTest::Unit::TestCase
+class PigLatinTest < Minitest::Test
   def test_word_beginning_with_a
     assert_equal 'appleay', PigLatin.translate('apple')
   end

--- a/point-mutations/point_mutations_test.rb
+++ b/point-mutations/point_mutations_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'dna'
 
-class DNATest < MiniTest::Unit::TestCase
+class DNATest < Minitest::Test
   def test_no_difference_between_empty_strands
     assert_equal 0, DNA.new('').hamming_distance('')
   end

--- a/prime-factors/prime_factors_test.rb
+++ b/prime-factors/prime_factors_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'prime_factors'
 
-class PrimeFactorsTest < MiniTest::Unit::TestCase
+class PrimeFactorsTest < Minitest::Test
   def test_1
     assert_equal [], PrimeFactors.for(1)
   end

--- a/protein-translation/protein_translation_test.rb
+++ b/protein-translation/protein_translation_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require_relative 'translation'
 
 # rubocop:disable Style/MethodName
-class TranslationTest < MiniTest::Unit::TestCase
+class TranslationTest < Minitest::Test
   def test_AUG_translates_to_methionine
     assert_equal 'Methionine', Translation.of_codon('AUG')
   end

--- a/proverb/proverb_test.rb
+++ b/proverb/proverb_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'proverb'
 
-class ProverbTest < MiniTest::Unit::TestCase
+class ProverbTest < Minitest::Test
   def test_a_single_consequence
     proverb = Proverb.new('nail', 'shoe')
     expected = "For want of a nail the shoe was lost.\n" \

--- a/pythagorean-triplet/pythagorean_triplet_test.rb
+++ b/pythagorean-triplet/pythagorean_triplet_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'triplet'
 
-class TripletTest < MiniTest::Unit::TestCase
+class TripletTest < Minitest::Test
   def test_sum
     assert_equal 12, Triplet.new(3, 4, 5).sum
   end

--- a/queen-attack/queen_attack_test.rb
+++ b/queen-attack/queen_attack_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'queens'
 
-class QueensTest < MiniTest::Unit::TestCase
+class QueensTest < Minitest::Test
   def test_default_positions
     queens = Queens.new
     assert_equal [0, 3], queens.white

--- a/raindrops/raindrops_test.rb
+++ b/raindrops/raindrops_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'raindrops'
 
-class RaindropsTest < MiniTest::Unit::TestCase
+class RaindropsTest < Minitest::Test
   def test_1
     assert_equal '1', Raindrops.convert(1)
   end

--- a/rna-transcription/complement_test.rb
+++ b/rna-transcription/complement_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'complement'
 
-class ComplementTest < MiniTest::Unit::TestCase
+class ComplementTest < Minitest::Test
   def test_rna_complement_of_cytosine_is_guanine
     assert_equal 'G', Complement.of_dna('C')
   end

--- a/robot-name/robot_name_test.rb
+++ b/robot-name/robot_name_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'robot'
 
-class RobotTest < MiniTest::Unit::TestCase
+class RobotTest < Minitest::Test
   def test_has_name
     # rubocop:disable Lint/AmbiguousRegexpLiteral
     assert_match /^[A-Z]{2}\d{3}$/, Robot.new.name

--- a/robot-simulator/robot_simulator_test.rb
+++ b/robot-simulator/robot_simulator_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'simulator'
 
-class RobotTurningTest < MiniTest::Unit::TestCase
+class RobotTurningTest < Minitest::Test
   attr_reader :robot
 
   def setup
@@ -123,7 +123,7 @@ class RobotTurningTest < MiniTest::Unit::TestCase
   end
 end
 
-class RobotSimulatorTest < MiniTest::Unit::TestCase
+class RobotSimulatorTest < Minitest::Test
   def simulator
     @simulator ||= Simulator.new
   end

--- a/roman-numerals/roman_numerals_test.rb
+++ b/roman-numerals/roman_numerals_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'roman'
 
-class RomanTest < MiniTest::Unit::TestCase
+class RomanTest < Minitest::Test
   def test_1
     assert_equal 'I', 1.to_roman
   end

--- a/saddle-points/saddle_points_test.rb
+++ b/saddle-points/saddle_points_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'matrix'
 
-class MatrixTest < MiniTest::Unit::TestCase
+class MatrixTest < Minitest::Test
   def test_extract_a_row
     matrix = Matrix.new("1 2\n10 20")
     assert_equal [1, 2], matrix.rows[0]

--- a/say/say_test.rb
+++ b/say/say_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'say'
 
-class SayTest < MiniTest::Unit::TestCase
+class SayTest < Minitest::Test
   def test_0
     assert_equal 'zero', Say.new(0).in_english
   end

--- a/scale-generator/scale_generator_test.rb
+++ b/scale-generator/scale_generator_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'scale'
 
-class ScaleGeneratorTest < MiniTest::Unit::TestCase
+class ScaleGeneratorTest < Minitest::Test
   def test_naming_scale
     chromatic = Scale.new('c', :chromatic)
     expected = 'C chromatic'

--- a/scrabble-score/scrabble_score_test.rb
+++ b/scrabble-score/scrabble_score_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'scrabble'
 
-class ScrabbleTest < MiniTest::Unit::TestCase
+class ScrabbleTest < Minitest::Test
   def test_empty_word_scores_zero
     assert_equal 0, Scrabble.new('').score
   end

--- a/secret-handshake/secret_handshake_test.rb
+++ b/secret-handshake/secret_handshake_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'secret_handshake'
 
-class SecretHandshakeTest < MiniTest::Unit::TestCase
+class SecretHandshakeTest < Minitest::Test
   def test_handshake_1_to_wink
     handshake = SecretHandshake.new(1)
     assert_equal ['wink'], handshake.commands

--- a/series/series_test.rb
+++ b/series/series_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'series'
 
-class SeriesTest < MiniTest::Unit::TestCase
+class SeriesTest < Minitest::Test
   def test_simple_slices_of_one
     series = Series.new('01234')
     assert_equal [[0], [1], [2], [3], [4]], series.slices(1)

--- a/sieve/sieve_test.rb
+++ b/sieve/sieve_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'sieve'
 
-class SieveTest < MiniTest::Unit::TestCase
+class SieveTest < Minitest::Test
   def test_a_few_primes
     expected = [2, 3, 5, 7]
     assert_equal expected, Sieve.new(10).primes

--- a/simple-cipher/simple_cipher_test.rb
+++ b/simple-cipher/simple_cipher_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'cipher'
 
-class RandomKeyCipherTest < MiniTest::Unit::TestCase
+class RandomKeyCipherTest < Minitest::Test
   def setup
     @cipher = Cipher.new
   end
@@ -32,7 +32,7 @@ class RandomKeyCipherTest < MiniTest::Unit::TestCase
   end
 end
 
-class IncorrectKeyCipherTest < MiniTest::Unit::TestCase
+class IncorrectKeyCipherTest < Minitest::Test
   def test_cipher_with_caps_key
     skip
     assert_raises ArgumentError do
@@ -55,7 +55,7 @@ class IncorrectKeyCipherTest < MiniTest::Unit::TestCase
   end
 end
 
-class SubstitutionCipherTest < MiniTest::Unit::TestCase
+class SubstitutionCipherTest < Minitest::Test
   def setup
     @key = 'abcdefghij'
     @cipher = Cipher.new(@key)
@@ -101,7 +101,7 @@ class SubstitutionCipherTest < MiniTest::Unit::TestCase
   end
 end
 
-class PseudoShiftCipherTest < MiniTest::Unit::TestCase
+class PseudoShiftCipherTest < Minitest::Test
   def setup
     @cipher = Cipher.new('dddddddddd')
   end

--- a/simple-linked-list/simple_linked_list_test.rb
+++ b/simple-linked-list/simple_linked_list_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 
 require_relative 'linked_list'
 
-class LinkedListTest < MiniTest::Unit::TestCase
+class LinkedListTest < Minitest::Test
   def setup
     @one = Element.new(1, nil)
     @two = Element.new(2, @one)

--- a/space-age/space_age_test.rb
+++ b/space-age/space_age_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'space_age'
 
-class SpaceAgeTest < MiniTest::Unit::TestCase
+class SpaceAgeTest < Minitest::Test
   def test_age_in_seconds
     age = SpaceAge.new(1_000_000)
     assert_equal 1_000_000, age.seconds

--- a/strain/strain_test.rb
+++ b/strain/strain_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'array'
 
-class ArrayTest < MiniTest::Unit::TestCase
+class ArrayTest < Minitest::Test
   def test_empty_keep
     assert_equal [], [].keep { |e| e < 10 }
   end

--- a/sum-of-multiples/sum_of_multiples_test.rb
+++ b/sum-of-multiples/sum_of_multiples_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'sum'
 
-class SumTest < MiniTest::Unit::TestCase
+class SumTest < Minitest::Test
   def test_sum_to_1
     assert_equal 0, SumOfMultiples.to(1)
   end

--- a/triangle/triangle_test.rb
+++ b/triangle/triangle_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'triangle'
 
-class TriangleTest < MiniTest::Unit::TestCase
+class TriangleTest < Minitest::Test
   def test_equilateral_triangles_have_equal_sides
     assert_equal :equilateral, Triangle.new(2, 2, 2).kind
   end

--- a/trinary/trinary_test.rb
+++ b/trinary/trinary_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'trinary'
 
-class TrinaryTest < MiniTest::Unit::TestCase
+class TrinaryTest < Minitest::Test
   def test_trinary_1_is_decimal_1
     assert_equal 1, Trinary.new('1').to_decimal
   end

--- a/twelve-days/twelve_days_test.rb
+++ b/twelve-days/twelve_days_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'twelve_days'
 
-class TwelveDaysTest < MiniTest::Unit::TestCase
+class TwelveDaysTest < Minitest::Test
   def song
     @song ||= ::TwelveDaysSong.new
   end

--- a/word-count/word_count_test.rb
+++ b/word-count/word_count_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'phrase'
 
-class PhraseTest < MiniTest::Unit::TestCase
+class PhraseTest < Minitest::Test
   def test_count_one_word
     phrase = Phrase.new('word')
     counts = { 'word' => 1 }

--- a/wordy/wordy_test.rb
+++ b/wordy/wordy_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'word_problem'
 
-class WordProblemTest < MiniTest::Unit::TestCase
+class WordProblemTest < Minitest::Test
   def test_add_1
     assert_equal 2, WordProblem.new('What is 1 plus 1?').answer
   end


### PR DESCRIPTION
I've been getting the following deprecation warning:

```
MiniTest::Unit::TestCase is now Minitest::Test. From hamming_test.rb:4:in `<main>'
```

So I've run

```bash
grep -rl MiniTest::Unit::TestCase . | sort | uniq | xargs sed -i s/MiniTest::Unit::TestCase/MiniTest::Test/g
```

I have not tested all of these -- I ran a couple by hand but make no promises.

If this causes compatibility problems, is there a way to suppress the deprecation warning?