### PR TITLE
Remove lower-case letters from regex

### DIFF
--- a/robot-name/robot_name_test.rb
+++ b/robot-name/robot_name_test.rb
@@ -4,7 +4,7 @@ require_relative 'robot'
 class RobotTest < MiniTest::Unit::TestCase
   def test_has_name
     # rubocop:disable Lint/AmbiguousRegexpLiteral
-    assert_match /^[a-zA-Z]{2}\d{3}$/, Robot.new.name
+    assert_match /^[A-Z]{2}\d{3}$/, Robot.new.name
     # rubocop:enable Lint/AmbiguousRegexpLiteral
   end
 
@@ -30,7 +30,7 @@ class RobotTest < MiniTest::Unit::TestCase
     name2 = robot.name
     assert name != name2
     # rubocop:disable Lint/AmbiguousRegexpLiteral
-    assert_match /^[a-zA-Z]{2}\d{3}$/, name2
+    assert_match /^[A-Z]{2}\d{3}$/, name2
     # rubocop:enable Lint/AmbiguousRegexpLiteral
   end
 end


### PR DESCRIPTION
In the README for this problem the letters are always in upper case. And
in the example solution, the `alphabet` method only returns upper case.
So I didn't think the tests needed to check for lower case letters.