### PR TITLE
Use UTC in gigasecond exercise to avoid daylight savings issues

### DIFF
--- a/gigasecond/gigasecond_test.rb
+++ b/gigasecond/gigasecond_test.rb
@@ -4,34 +4,34 @@ require 'time'
 
 require_relative 'gigasecond'
 class GigasecondTest < Minitest::Unit::TestCase
-  def test_1_winter_time
-    gs = Gigasecond.from(Time.new(2011, 4, 25))
-    assert_equal Time.new(2043, 1, 1, 0 , 46, 40), gs
+  def test_1
+    gs = Gigasecond.from(Time.utc(2011, 4, 25))
+    assert_equal Time.utc(2043, 1, 1, 1, 46, 40), gs
   end
 
-  def test_2_winter_time
+  def test_2
     skip
-    gs = Gigasecond.from(Time.new(1977, 6, 13))
-    assert_equal Time.new(2009, 2, 19, 0, 46, 40), gs
+    gs = Gigasecond.from(Time.utc(1977, 6, 13))
+    assert_equal Time.utc(2009, 2, 19, 1, 46, 40), gs
   end
 
-  def test_3_summer_time
+  def test_3
     skip
-    gs = Gigasecond.from(Time.new(1959, 7, 19))
-    assert_equal Time.new(1991, 3, 27, 0, 46, 40), gs
+    gs = Gigasecond.from(Time.utc(1959, 7, 19))
+    assert_equal Time.utc(1991, 3, 27, 1, 46, 40), gs
   end
 
-  def test_4_summer_time_with_seconds
+  def test_4_with_seconds
     skip
-    gs = Gigasecond.from(Time.new(1959, 7, 19, 23, 59, 59))
-    assert_equal Time.new(1991, 3, 28, 0, 46, 39), gs
+    gs = Gigasecond.from(Time.utc(1959, 7, 19, 23, 59, 59))
+    assert_equal Time.utc(1991, 3, 28, 1, 46, 39), gs
   end
 
   # modify the test to test your 1 Gs anniversary
   def test_5_with_your_birthday
     skip
-    your_birthday = Time.new(year, month, day)
+    your_birthday = Time.utc(year, month, day)
     gs = Gigasecond.from(your_birthday)
-    assert_equal Time.new(2009, 1, 31), gs
+    assert_equal Time.utc(2009, 1, 31, 1, 46, 39), gs
   end
 end


### PR DESCRIPTION
I think it would make sense to change the tests to use UTC times to avoid daylight savings.

I copied the other tests when writing the "your birthday" test like so:
```ruby
# modify the test to test your 1 Gs anniversary
def test_5_with_your_birthday
  your_birthday = Time.new(1987, 3, 24)
  gs = Gigasecond.from(your_birthday)
  assert_equal Time.new(2018, 11, 30, 0, 46, 40), gs
end
```

I was surprised when it failed:
```
GigasecondTest#test_5_with_your_birthday [gigasecond_test.rb:31]:
Expected: 2018-11-30 00:46:40 +0000
  Actual: 2018-11-30 01:46:40 +0000
```
but when I checked it, this made sense -- one gigasecond is 31y 259d 1h 46m and 40s, so the `01:46:40` is what I'd expect, not `00:46:40` like in the other tests. There's an hour missing somewhere!

It turns out that (on my UK-based machine) all the tests have the input time in British Summer Time, and the gigasecond anniversary in GMT:
```
# test_1
Time.new(2011, 4, 25).zone # => "BST"
Time.new(2043, 1, 1, 0 , 46, 40).zone # => "GMT"

# test_2
Time.new(1977, 6, 13).zone # => "BST"
Time.new(2009, 2, 19, 0, 46, 40).zone # => "GMT"

# test_3
Time.new(1959, 7, 19).zone # => "BST"
Time.new(1991, 3, 27, 0, 46, 40).zone # => "GMT"

# test_time_with_seconds
Time.new(1959, 7, 19, 23, 59, 59).zone # => "BST"
Time.new(1991, 3, 28, 0, 46, 39).zone # => "GMT"
```

However, both my birthday and my gigasecond anniversary are in GMT:
```ruby
# test_yourself
Time.new(1987, 3, 24).zone # => "GMT"
Time.new(2018, 11, 30, 1, 46, 40).zone # => "GMT"
```

In fact, the existing tests will fail in countries that have different daylight savings rules, like [New Zealand](https://www.wolframalpha.com/input/?i=1+gigasecond+from+midnight+2011-04-25+in+new+zealand).