### PR TITLE
Correct number of arguments to set in getting started file

### DIFF
--- a/hamming/GETTING_STARTED.md
+++ b/hamming/GETTING_STARTED.md
@@ -73,17 +73,17 @@ Run the test again.
     ArgumentError: wrong number of arguments (2 for 0)
       in `compute' hamming_test.rb:12:in `test_no_difference_between_identical_strands'
 
-The method `compute` needs to take an argument.
+The method `compute` needs to take two arguments.
 
 These are examples of method definitions that take arguments:
 
     def self.greet(name)
     end
 
-    def self.drink(beverage)
+    def self.drink(beverage,size)
     end
 
-Change the `compute` method definition so it takes an argument.
+Change the `compute` method definition so it takes two arguments.
 
 ## Step 5
 


### PR DESCRIPTION
GETTING_STARTED.md was misleading when it mentioned the method needed "an argument" when it needs two arguments.  Since a lot of newbies start on this exercism, I thought it would be less frustrating if they don't get stuck on this step. :)