### PR TITLE
Make references to minitest module consistent across all exercises

### DIFF
--- a/gigasecond/gigasecond_test.rb
+++ b/gigasecond/gigasecond_test.rb
@@ -3,7 +3,7 @@ require 'date'
 require 'time'
 
 require_relative 'gigasecond'
-class GigasecondTest < Minitest::Unit::TestCase
+class GigasecondTest < MiniTest::Unit::TestCase
   def test_1
     gs = Gigasecond.from(Time.utc(2011, 4, 25))
     assert_equal Time.utc(2043, 1, 1, 1, 46, 40), gs

--- a/largest-series-product/largest_series_product_test.rb
+++ b/largest-series-product/largest_series_product_test.rb
@@ -4,7 +4,7 @@ require_relative 'series'
 # Rubocop directives
 # rubocop:disable Lint/ParenthesesAsGroupedExpression
 #
-class Seriestest < Minitest::Unit::TestCase
+class Seriestest < MiniTest::Unit::TestCase
   def test_digits
     assert_equal (0..9).to_a, Series.new('0123456789').digits
   end

--- a/protein-translation/protein_translation_test.rb
+++ b/protein-translation/protein_translation_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require_relative 'translation'
 
 # rubocop:disable Style/MethodName
-class TranslationTest < Minitest::Unit::TestCase
+class TranslationTest < MiniTest::Unit::TestCase
   def test_AUG_translates_to_methionine
     assert_equal 'Methionine', Translation.of_codon('AUG')
   end


### PR DESCRIPTION
Three of the exercise directories (gigasecond, largest-series-product and protein-translation) contain *_test.rb files which refer to the Minitest module rather than the MiniTest module. For consistency these references have been changed to MiniTest.