### PR TITLE
Add new scale-name test to scale_generator_test.rb

### DIFF
--- a/gigasecond/gigasecond_test.rb
+++ b/gigasecond/gigasecond_test.rb
@@ -3,7 +3,7 @@ require 'date'
 require 'time'
 
 require_relative 'gigasecond'
-class GigasecondTest < Minitest::Unit::TestCase
+class GigasecondTest < MiniTest::Unit::TestCase
   def test_1
     gs = Gigasecond.from(Time.utc(2011, 4, 25))
     assert_equal Time.utc(2043, 1, 1, 1, 46, 40), gs

--- a/largest-series-product/largest_series_product_test.rb
+++ b/largest-series-product/largest_series_product_test.rb
@@ -4,7 +4,7 @@ require_relative 'series'
 # Rubocop directives
 # rubocop:disable Lint/ParenthesesAsGroupedExpression
 #
-class Seriestest < Minitest::Unit::TestCase
+class Seriestest < MiniTest::Unit::TestCase
   def test_digits
     assert_equal (0..9).to_a, Series.new('0123456789').digits
   end

--- a/protein-translation/protein_translation_test.rb
+++ b/protein-translation/protein_translation_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require_relative 'translation'
 
 # rubocop:disable Style/MethodName
-class TranslationTest < Minitest::Unit::TestCase
+class TranslationTest < MiniTest::Unit::TestCase
   def test_AUG_translates_to_methionine
     assert_equal 'Methionine', Translation.of_codon('AUG')
   end

--- a/scale-generator/scale_generator_test.rb
+++ b/scale-generator/scale_generator_test.rb
@@ -25,6 +25,13 @@ class ScaleGeneratorTest < MiniTest::Unit::TestCase
     assert_equal expected, actual
   end
 
+  def test_naming_major_scale
+    major = Scale.new('G', :major, 'MMmMMMm')
+    expected = 'G major'
+    actual = major.name
+    assert_equal expected, actual
+  end
+
   def test_major_scale
     skip
     major = Scale.new('C', :major, 'MMmMMMm')


### PR DESCRIPTION
Only one test (test_naming_scale) currently asserts against Scale#name meaning that a compliant implementation could contain a hard coded value of 'C chromatic'. This change adds a new test (test_naming_major_scale) which asserts against Scale#name with a different tonic and scale-name.