### PR TITLE
squares: subsequent calls should have same value

### DIFF
--- a/difference-of-squares/difference_of_squares_test.rb
+++ b/difference-of-squares/difference_of_squares_test.rb
@@ -45,4 +45,10 @@ class SquaresTest < MiniTest::Unit::TestCase
     skip
     assert_equal 25_164_150, Squares.new(100).difference
   end
+
+  def test_consistent_difference
+    skip
+    squares = Squares.new(10)
+    assert_equal squares.difference, squares.difference
+  end
 end


### PR DESCRIPTION
Since the API calls for a `Squares` object to be instantiated with a specific max value, it seems to be implied that the instance methods of a given instance should have the same result on subsequent calls. While not common, I have seen more than one submission that didn't have this property.