### PR TITLE
Add exception handling for wrong nucleotides.

### DIFF
--- a/rna-transcription/complement_test.rb
+++ b/rna-transcription/complement_test.rb
@@ -50,4 +50,14 @@ class ComplementTest < Minitest::Test
     skip
     assert_equal 'ACTTGGGCTGTAC', Complement.of_rna('UGAACCCGACAUG')
   end
+
+  def test_dna_raises_argument_error
+    skip
+    assert_raises(ArgumentError){ Complement.of_dna('U') }
+  end
+
+  def test_rna_raises_argument_error
+    skip
+    assert_raises(ArgumentError){ Complement.of_rna('T') }
+  end
 end

--- a/rna-transcription/example.rb
+++ b/rna-transcription/example.rb
@@ -1,9 +1,27 @@
 class Complement
   def self.of_dna(strand)
-    strand.tr('CGTA', 'GCAU')
+    DNA.new(strand).tr('CGTA', 'GCAU')
   end
 
   def self.of_rna(strand)
-    strand.tr('GCAU', 'CGTA')
+    RNA.new(strand).tr('GCAU', 'CGTA')
+  end
+end
+
+class DNA < String
+  def initialize strand
+    strand.chars.map do |n|
+      raise ArgumentError, "Illegal DNA Nucleotide: #{n}" unless ['G', 'C', 'T', 'A'].include? n
+    end
+    super
+  end
+end
+
+class RNA < String
+  def initialize strand
+    strand.chars.map do |n|
+      raise ArgumentError, "Illegal RNA Nucleotide: #{n}" unless ['G', 'C', 'U', 'A'].include? n
+    end
+    super
   end
 end


### PR DESCRIPTION
I noticed that other language versions of this exercise handle argument errors
for the nucleotides.  This commit adds some new tests to check against bogus
nucleotides.