### PR TITLE
Fix test suite for robot-name excercise

### DIFF
--- a/robot-name/robot_name_test.rb
+++ b/robot-name/robot_name_test.rb
@@ -29,6 +29,7 @@ class RobotTest < Minitest::Test
     robot.reset
     name2 = robot.name
     assert name != name2
+    assert_equal name2, robot.name, "Command/Query Separation: query methods should generally not change object state"
     # rubocop:disable Lint/AmbiguousRegexpLiteral
     assert_match /^[A-Z]{2}\d{3}$/, name2
     # rubocop:enable Lint/AmbiguousRegexpLiteral


### PR DESCRIPTION
Consider a robot whose `reset` state is set to *true*, and this state is used to determine if a new name should be generated and returned. 

The current test suite will pass even if the programmer forgets to "unset" the robot's `reset` state after a call to name, thereby generating and returning a new name whenever the `name` method is called, ad infinitum. 

The proposed changes to the test suite would test that the `reset` state has been set to "off" or its equivalent. 