### PR TITLE
Space Age: Don't compare floats using ==

### DIFF
--- a/space-age/example.rb
+++ b/space-age/example.rb
@@ -17,7 +17,7 @@ class SpaceAge
   }.each do |planet, orbital_period|
 
     define_method("on_#{planet}") do
-      (seconds / orbital_period).round(2)
+      seconds / orbital_period
     end
 
   end

--- a/space-age/space_age_test.rb
+++ b/space-age/space_age_test.rb
@@ -2,63 +2,65 @@ require 'minitest/autorun'
 require_relative 'space_age'
 
 class SpaceAgeTest < Minitest::Test
+  DELTA = 0.01
+
   def test_age_in_seconds
     age = SpaceAge.new(1_000_000)
-    assert_equal 1_000_000, age.seconds
+    assert_in_delta 1_000_000, age.seconds, DELTA
   end
 
   def test_age_in_earth_years
     skip
     age = SpaceAge.new(1_000_000_000)
-    assert_equal 31.69, age.on_earth
+    assert_in_delta 31.69, age.on_earth, DELTA
   end
 
   def test_age_in_mercury_years
     skip
     age = SpaceAge.new(2_134_835_688)
-    assert_equal 67.65, age.on_earth
-    assert_equal 280.88, age.on_mercury
+    assert_in_delta 67.65, age.on_earth, DELTA
+    assert_in_delta 280.88, age.on_mercury, DELTA
   end
 
   def test_age_in_venus_years
     skip
     age = SpaceAge.new(189_839_836)
-    assert_equal 6.02, age.on_earth
-    assert_equal 9.78, age.on_venus
+    assert_in_delta 6.02, age.on_earth, DELTA
+    assert_in_delta 9.78, age.on_venus, DELTA
   end
 
   def test_age_on_mars
     skip
     age = SpaceAge.new(2_329_871_239)
-    assert_equal 73.83, age.on_earth
-    assert_equal 39.25, age.on_mars
+    assert_in_delta 73.83, age.on_earth, DELTA
+    assert_in_delta 39.25, age.on_mars, DELTA
   end
 
   def test_age_on_jupiter
     skip
     age = SpaceAge.new(901_876_382)
-    assert_equal 28.58, age.on_earth
-    assert_equal 2.41, age.on_jupiter
+    assert_in_delta 28.58, age.on_earth, DELTA
+    assert_in_delta 2.41, age.on_jupiter, DELTA
   end
 
   def test_age_on_saturn
     skip
     age = SpaceAge.new(3_000_000_000)
-    assert_equal 95.06, age.on_earth
-    assert_equal 3.23, age.on_saturn
+    assert_in_delta 95.06, age.on_earth, DELTA
+    assert_in_delta 3.23, age.on_saturn, DELTA
   end
 
   def test_age_on_uranus
     skip
     age = SpaceAge.new(3_210_123_456)
-    assert_equal 101.72, age.on_earth
-    assert_equal 1.21, age.on_uranus
+    assert_in_delta 101.72, age.on_earth, DELTA
+    assert_in_delta 1.21, age.on_uranus, DELTA
   end
 
   def test_age_on_neptune
     skip
     age = SpaceAge.new(8_210_123_456)
-    assert_equal 260.16, age.on_earth
-    assert_equal 1.58, age.on_neptune
+    assert_in_delta 260.16, age.on_earth, DELTA
+    assert_in_delta 1.58, age.on_neptune, DELTA
   end
 end


### PR DESCRIPTION
It's bad form to compare floats with each other using == and Exercism shouldn't be showing this to aspiring programmers.

[As the standard lib docs says](http://ruby-doc.org/stdlib-1.9.2/libdoc/minitest/unit/rdoc/MiniTest/Assertions.html#method-i-assert_in_delta) `asset_in_delta` should be used to compare floats.

The modified test pass with code designed for the old test (i.e. with `round(2)` after the division) and allows new code not to have to round the division which feels unnatural (it should not a responsibility of
`SpaceAge` to round its output).