### PR TITLE
Updated space age tests to properly compare floats

### DIFF
--- a/space-age/space_age_test.rb
+++ b/space-age/space_age_test.rb
@@ -10,55 +10,56 @@ class SpaceAgeTest < Minitest::Test
   def test_age_in_earth_years
     skip
     age = SpaceAge.new(1_000_000_000)
-    assert_equal 31.69, age.on_earth
+    assert_in_delta 31.69, age.on_earth, 0.01
   end
 
   def test_age_in_mercury_years
     skip
     age = SpaceAge.new(2_134_835_688)
-    assert_equal 67.65, age.on_earth
-    assert_equal 280.88, age.on_mercury
+    assert_in_delta 67.65, age.on_earth, 0.01
+    assert_in_delta 280.88, age.on_mercury, 0.01
   end
 
   def test_age_in_venus_years
     skip
     age = SpaceAge.new(189_839_836)
-    assert_equal 6.02, age.on_earth
-    assert_equal 9.78, age.on_venus
+    assert_in_delta 6.02, age.on_earth, 0.01
+    assert_in_delta 9.78, age.on_venus, 0.01
   end
 
   def test_age_on_mars
     skip
     age = SpaceAge.new(2_329_871_239)
-    assert_equal 73.83, age.on_earth
-    assert_equal 39.25, age.on_mars
+    assert_in_delta 73.83, age.on_earth, 0.01
+    assert_in_delta 39.25, age.on_mars, 0.01
   end
 
   def test_age_on_jupiter
     skip
     age = SpaceAge.new(901_876_382)
-    assert_equal 28.58, age.on_earth
-    assert_equal 2.41, age.on_jupiter
+    assert_in_delta 28.58, age.on_earth, 0.01
+    assert_in_delta 2.41, age.on_jupiter, 0.01
   end
 
   def test_age_on_saturn
     skip
     age = SpaceAge.new(3_000_000_000)
-    assert_equal 95.06, age.on_earth
-    assert_equal 3.23, age.on_saturn
+    assert_in_delta 95.06, age.on_earth, 0.01
+    assert_in_delta 3.23, age.on_saturn, 0.01
   end
 
   def test_age_on_uranus
     skip
     age = SpaceAge.new(3_210_123_456)
-    assert_equal 101.72, age.on_earth
-    assert_equal 1.21, age.on_uranus
+    assert_in_delta 101.72, age.on_earth, 0.01
+    assert_in_delta 1.21, age.on_uranus, 0.01
   end
 
   def test_age_on_neptune
     skip
     age = SpaceAge.new(8_210_123_456)
-    assert_equal 260.16, age.on_earth
-    assert_equal 1.58, age.on_neptune
+    assert_in_delta 260.16, age.on_earth, 0.01
+    assert_in_delta 1.58, age.on_neptune, 0.01
   end
 end
+


### PR DESCRIPTION
The tests originally used assert_equal. Changed them to assert_delta_in
where appropriate.