### PR TITLE
Fetch appropriate configlet binary

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -2,7 +2,31 @@
 
 LATEST=https://github.com/exercism/configlet/releases/latest
 
+OS=$(
+case $(uname) in
+    Darwin*)
+        echo "mac";;
+    Linux*)
+        echo "linux";;
+    Windows*)
+        echo "windows";;
+    *)
+        echo "linux";;
+esac)
+
+ARCH=$(
+case $(uname -m) in
+    *64*)
+        echo 64bit;;
+    *686*)
+        echo 32bit;;
+    *386*)
+        echo 32bit;;
+    *)
+        echo 64bit;;
+esac)
+
 VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
-URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-linux-64bit.tgz
+URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
 
 curl -s --location $URL | tar xz -C bin/


### PR DESCRIPTION
  I noticed that when I am working on my Mac the fetched configlet binary fails.

  This pull request adds a limited but smarter configlet binary fetcher that
  tries to determine the OS and architecture and fetch the appropriate
  configlet binary.
