### PR TITLE
Add link to exercism help in setup.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,4 +1,5 @@
-You will need the Minitest gem. To install it, open a
-terminal window and run:
+Refer exercism help page at http://help.exercism.io/getting-started-with-ruby.html for ruby installation and learning resources.
+
+For running the tests provided, you will need the Minitest gem. Open a terminal window and run the following command to install minitest:
 
     gem install minitest


### PR DESCRIPTION
It will be better if the link to exercism help page for ruby is provided
in the README. In fact, it should be provided for other languages as
well.

Also make it clear that minitest is required for running the tests and
not for solving the exercise in particular.