### PR TITLE
Modify tests so that identical instances are not necessary

### DIFF
--- a/grains/example.rb
+++ b/grains/example.rb
@@ -1,11 +1,9 @@
 class Grains
-  def square(number)
+  def self.square(number)
     2**(number - 1)
   end
 
-  def total
-    @total ||= (1..64).inject(0) do |sum, number|
-      sum + square(number)
-    end
+  def self.total
+    square(65) - 1
   end
 end

--- a/grains/grains_test.rb
+++ b/grains/grains_test.rb
@@ -3,41 +3,41 @@ require_relative 'grains'
 
 class GrainsTest < Minitest::Test
   def test_square_1
-    assert_equal 1, Grains.new.square(1)
+    assert_equal 1, Grains.square(1)
   end
 
   def test_square_2
     skip
-    assert_equal 2, Grains.new.square(2)
+    assert_equal 2, Grains.square(2)
   end
 
   def test_square_3
     skip
-    assert_equal 4, Grains.new.square(3)
+    assert_equal 4, Grains.square(3)
   end
 
   def test_square_4
     skip
-    assert_equal 8, Grains.new.square(4)
+    assert_equal 8, Grains.square(4)
   end
 
   def test_square_16
     skip
-    assert_equal 32_768, Grains.new.square(16)
+    assert_equal 32_768, Grains.square(16)
   end
 
   def test_square_32
     skip
-    assert_equal 2_147_483_648, Grains.new.square(32)
+    assert_equal 2_147_483_648, Grains.square(32)
   end
 
   def test_square_64
     skip
-    assert_equal 9_223_372_036_854_775_808, Grains.new.square(64)
+    assert_equal 9_223_372_036_854_775_808, Grains.square(64)
   end
 
   def test_total_grains
     skip
-    assert_equal 18_446_744_073_709_551_615, Grains.new.total
+    assert_equal 18_446_744_073_709_551_615, Grains.total
   end
 end


### PR DESCRIPTION
The current test suite requires new instances to be created by sending the `new` message to the `Grains` class. 

These new instances are exactly identical at time of creation, and won't differ in the future. It therefore doesn't make sense to create them. 

I have changed the test suite to test class methods instead of instances methods, and therefore avoid a solution that requires new instances. This rewrite is in keeping with the other exercises in the Ruby suite. 