### PR TITLE
Fixes the incorrect crypto-square tests

### DIFF
--- a/crypto-square/crypto_square_test.rb
+++ b/crypto-square/crypto_square_test.rb
@@ -69,7 +69,7 @@ class CryptoTest < Minitest::Test
   end
 
   def test_normalized_ciphertext
-    skip("Skip")
+    skip
     crypto = Crypto.new('Vampires are people too!')
     assert_equal 'vrel aepe mset paoo irpo', crypto.normalize_ciphertext
   end
@@ -77,15 +77,16 @@ class CryptoTest < Minitest::Test
   def test_normalized_ciphertext_spills_into_short_segment
     skip
     crypto = Crypto.new('Madness, and then illumination.')
-    assert_equal 'msemo aanin dninn dlaet ltshu i', crypto.normalize_ciphertext
+    expected = 'msemo aanin dnin ndla etlt shui'
+    assert_equal expected, crypto.normalize_ciphertext
   end
 
   def test_another_normalized_ciphertext
-    skip("Skip")
+    skip
     crypto = Crypto.new(
       'If man was meant to stay on the ground god would have given us roots'
     )
-    expected = 'imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghns seoau'
+    expected = 'imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau'
     assert_equal expected, crypto.normalize_ciphertext
   end
 
@@ -97,7 +98,7 @@ class CryptoTest < Minitest::Test
   end
 
   def test_normalized_ciphertext_when_just_less_then_a_full_square
-    skip("Skip")
+    skip
     crypto = Crypto.new('I am')
     assert_equal 'im a', crypto.normalize_ciphertext
   end

--- a/crypto-square/example.rb
+++ b/crypto-square/example.rb
@@ -1,34 +1,39 @@
 class Crypto
-  attr_reader :plaintext
+
   def initialize(plaintext)
     @plaintext = plaintext
   end
 
   def normalize_plaintext
-    @normalized ||= plaintext.downcase.gsub(/\W/, '')
+    @normalized ||= @plaintext.downcase.gsub(/\W/, '')
+  end
+
+  def plaintext_segments
+    normalize_plaintext.chars.
+                        each_slice(size).
+                        map{ |s| s.join('') }.
+                        to_a
   end
 
   def size
     Math.sqrt(normalize_plaintext.length).ceil
   end
 
-  def plaintext_segments
-    chunk(normalize_plaintext, size)
-  end
-
   def ciphertext
-    plaintext_segments.map do |segment|
-      # There has to be a better way to make sure that
-      # the last segment is as long as the others!
-      segment.split('').fill('', segment.length...size)
-    end.transpose.flatten.join
+    transposed.join('')
   end
 
   def normalize_ciphertext
-    chunk(ciphertext, 5).join(' ')
+    transposed.join(' ')
   end
 
-  def chunk(s, size)
-    s.scan(/.{1,#{size}}/)
+  private 
+
+  def transposed
+    chunk_size = size
+    chunks = plaintext_segments.map do |s|
+        Array.new(chunk_size) { |i| s[i] or '' }
+    end
+    chunks.transpose.map{ |s| s.join('') }
   end
 end


### PR DESCRIPTION
The tests for crypto-square expected incorrect rows in the normalised ciphertext, contradicting the README and other more conformant implementations. In addition the example itself was failing some of the existing (correct) tests.