### PR TITLE
Use travis.ci containers for faster builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 
+sudo: false # use containers for faster builds
+
 rvm:
   - 2.1.2
 


### PR DESCRIPTION
This change-set adds the `sudo` flag which allows travis to use containers rather than VMs, which means
much faster build allocation.