### PR TITLE
Add numeric string test

### DIFF
--- a/binary/binary_test.rb
+++ b/binary/binary_test.rb
@@ -36,8 +36,13 @@ class BinaryTest < Minitest::Test
     assert_equal 1128, Binary.new('10001101000').to_decimal
   end
 
-  def test_invalid_binary_is_decimal_0
+  def test_invalid_binary_string_is_decimal_0
     skip
     assert_equal 0, Binary.new('carrot123').to_decimal
+  end
+
+  def test_invalid_binary_numeric_string_is_decimal_0
+    skip
+    assert_equal 0, Binary.new('123').to_decimal
   end
 end


### PR DESCRIPTION
Base on https://github.com/exercism/xruby/issues/135

I noticed while working on this solution that the case where a binary string is only numbers, i.e. 123 isn't covered. I noticed this while trying to determine if a string was valid I could pass the tests by doing something along the lines of:
```ruby
   def to_decimal
    return 0 if n.to_i == 0
    n.reverse.each_char.with_index.map { |char, index| char.to_i * 2**index }.reduce(:+)
  end
```
the test for string carrot123 returns 0, which is fine, but if i put 123 as a string my method would return a value,11 in this case.