### PR TITLE
prevent empty linked lists from being represented as nil

### DIFF
--- a/simple-linked-list/example.rb
+++ b/simple-linked-list/example.rb
@@ -3,7 +3,7 @@ class Element
   attr_reader :next
 
   def self.from_a(arr)
-    arr.reverse_each.inject(nil) { |memo, obj| new(obj, memo) }
+    arr.reverse_each.inject(NullElement.new) { |memo, obj| new(obj, memo) }
   end
 
   def self.each_datum(elem)
@@ -25,7 +25,7 @@ class Element
     res
   end
 
-  def initialize(datum, next_element = nil)
+  def initialize(datum, next_element = NullElement.new)
     @datum = datum
     @next = next_element
   end
@@ -40,5 +40,27 @@ class Element
 
   def reverse
     self.class.reverse(self)
+  end
+end
+
+class NullElement
+  def to_a
+    []
+  end
+
+  def reverse
+    self
+  end
+
+  def datum
+    nil
+  end
+
+  def next
+    nil
+  end
+
+  def nil?
+    true
   end
 end

--- a/simple-linked-list/simple_linked_list_test.rb
+++ b/simple-linked-list/simple_linked_list_test.rb
@@ -64,4 +64,10 @@ class LinkedListTest < Minitest::Test
     # rubocop:disable Lint/ParenthesesAsGroupedExpression
     assert_equal (1..10).to_a, Element.from_a(1..10).to_a
   end
+
+  def test_empty_list_operations
+    skip
+    assert_equal [], Element.from_a([]).to_a
+    assert_equal [], Element.from_a([]).reverse.to_a
+  end
 end


### PR DESCRIPTION
I'm submitting this on behalf of @zvkemp in order to close https://github.com/exercism/xruby/pull/83