### PR TITLE
Convenience library

### DIFF
--- a/lib/disable_skip.rb
+++ b/lib/disable_skip.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+# You can use this to disabe all skips in the current exercise by issuing the
+# following command:
+#     ruby -I../lib -rdisable_skip <fiename_test.rb>
+
+class Minitest
+  class Test
+    def skip
+    end
+  end
+end


### PR DESCRIPTION
Use this to disable skip directives in the tests so we don't need to
remember to replace or delete code while we are evaluating.