### PR TITLE
Exempt bin directory from style violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - '*/example.rb'
+    - 'bin/*'
 Style/Documentation:
   Enabled: false
 Style/StringLiterals:


### PR DESCRIPTION
I prefer to have commands use a hyphen rather than snake case, but rubocop complains
about things like generate-hamming.