### PR TITLE
Fix style violations in hello world

### DIFF
--- a/hello-world/hello_world_test.rb
+++ b/hello-world/hello_world_test.rb
@@ -9,22 +9,31 @@ end
 
 class HelloWorldTest < Minitest::Test
   def test_no_name
-    assert_equal 'Hello, World!', HelloWorld.hello, 'When given no name, it should greet the world!'
+    assert_equal 'Hello, World!', HelloWorld.hello, <<-MSG
+    When given no name, it should greet the world!
+    MSG
   end
 
   def test_sample_name
     skip
-    assert_equal 'Hello, Alice!', HelloWorld.hello('Alice'), 'When given "Alice" it should greet Alice!'
+    assert_equal 'Hello, Alice!', HelloWorld.hello('Alice'), <<-MSG
+    When given "Alice" it should greet Alice!
+    MSG
   end
 
   def test_other_sample_name
     skip
-    assert_equal 'Hello, Bob!', HelloWorld.hello('Bob'), 'When given "Bob" it should greet Bob!'
+    assert_equal 'Hello, Bob!', HelloWorld.hello('Bob'), <<-MSG
+    When given "Bob" it should greet Bob!
+    MSG
   end
 
   def test_no_strange_name
     skip
-    assert_equal 'Hello, !', HelloWorld.hello(''), 'When given an empty string it should have a space and punctuation, though admittedly this is strange.'
+    assert_equal 'Hello, !', HelloWorld.hello(''), <<-MSG
+    When given an empty string it should have a space
+    and punctuation, though admittedly this is strange.
+    MSG
   end
 end
 


### PR DESCRIPTION
The hello world test suite triggered "long line" violations.

This uses a heredoc to move the actual failure message below the assertion.
Another option would have been to assign a temporary variable on the line above the assertion.