### PR TITLE
Fix style violations in robot-name

### DIFF
--- a/robot-name/robot_name_test.rb
+++ b/robot-name/robot_name_test.rb
@@ -7,10 +7,10 @@ class RobotTest < Minitest::Test
     Query methods should generally not change object state.
   MSG
 
+  NAME_REGEXP = /^[A-Z]{2}\d{3}$/
+
   def test_has_name
-    # rubocop:disable Lint/AmbiguousRegexpLiteral
-    assert_match /^[A-Z]{2}\d{3}$/, Robot.new.name
-    # rubocop:enable Lint/AmbiguousRegexpLiteral
+    assert_match NAME_REGEXP, Robot.new.name
   end
 
   def test_name_sticks
@@ -22,9 +22,7 @@ class RobotTest < Minitest::Test
 
   def test_different_robots_have_different_names
     skip
-    # rubocop:disable Lint/UselessComparison
-    assert Robot.new.name != Robot.new.name
-    # rubocop:enable Lint/UselessComparison
+    refute_equal Robot.new.name, Robot.new.name
   end
 
   def test_reset_name
@@ -35,8 +33,6 @@ class RobotTest < Minitest::Test
     name2 = robot.name
     assert name != name2
     assert_equal name2, robot.name, COMMAND_QUERY
-    # rubocop:disable Lint/AmbiguousRegexpLiteral
-    assert_match /^[A-Z]{2}\d{3}$/, name2
-    # rubocop:enable Lint/AmbiguousRegexpLiteral
+    assert_match NAME_REGEXP, name2
   end
 end

--- a/robot-name/robot_name_test.rb
+++ b/robot-name/robot_name_test.rb
@@ -2,6 +2,11 @@ require 'minitest/autorun'
 require_relative 'robot_name'
 
 class RobotTest < Minitest::Test
+  COMMAND_QUERY = <<-MSG
+    Command/Query Separation:
+    Query methods should generally not change object state.
+  MSG
+
   def test_has_name
     # rubocop:disable Lint/AmbiguousRegexpLiteral
     assert_match /^[A-Z]{2}\d{3}$/, Robot.new.name
@@ -29,7 +34,7 @@ class RobotTest < Minitest::Test
     robot.reset
     name2 = robot.name
     assert name != name2
-    assert_equal name2, robot.name, 'Command/Query Separation: query methods should generally not change object state'
+    assert_equal name2, robot.name, COMMAND_QUERY
     # rubocop:disable Lint/AmbiguousRegexpLiteral
     assert_match /^[A-Z]{2}\d{3}$/, name2
     # rubocop:enable Lint/AmbiguousRegexpLiteral


### PR DESCRIPTION
Rubocop was complaining about a long line. At first I changed
the failure message to be a heredoc, which triggered a "long method"
violation.

This feels a bit dirty, in that the method is legitimately long, but
perhaps it's not too bad to make the message a constant.