### PR TITLE
Make acronym table-driven

### DIFF
--- a/acronym/acronym_test.rb
+++ b/acronym/acronym_test.rb
@@ -2,32 +2,24 @@ require 'minitest/autorun'
 require_relative 'acronym'
 
 class AcronymTest < Minitest::Test
-  def test_png
-    assert_equal 'PNG', Acronym.abbreviate('Portable Network Graphics')
+  def test_acronyms
+    {
+      'Portable Network Graphics' => 'PNG',
+      'Ruby on Rails' => 'ROR',
+      'HyperText Markup Language' => 'HTML',
+      'First In, First Out' => 'FIFO',
+      'PHP: Hypertext Preprocessor' => 'PHP',
+      'Complementary metal-oxide semiconductor' => 'CMOS',
+    }.each do |given, expected|
+      assert_equal expected, Acronym.abbreviate(given), <<-MSG
+        The acronym of '#{given}' should be '#{expected}'.
+      MSG
+    end
   end
 
-  def test_ruby_on_rails
-    skip
-    assert_equal 'ROR', Acronym.abbreviate('Ruby on Rails')
-  end
-
-  def test_html
-    skip
-    assert_equal 'HTML', Acronym.abbreviate('HyperText Markup Language')
-  end
-
-  def test_fifo
-    skip
-    assert_equal 'FIFO', Acronym.abbreviate('First In, First Out')
-  end
-
-  def test_php
-    skip
-    assert_equal 'PHP', Acronym.abbreviate('PHP: Hypertext Preprocessor')
-  end
-
-  def test_cmos
-    skip
-    assert_equal 'CMOS', Acronym.abbreviate('Complementary metal-oxide semiconductor')
+  # This is some simple book-keeping to let people who are
+  # giving feedback know which version of the exercise you solved.
+  def test_version
+    assert_equal 1, Acronym::VERSION
   end
 end

--- a/acronym/example.rb
+++ b/acronym/example.rb
@@ -1,4 +1,6 @@
 class Acronym
+  VERSION = 1
+
   def self.abbreviate(phrase)
     [].tap do |letters|
       each_word(phrase) do |word|


### PR DESCRIPTION
This may or may not be a good idea. It's not very idiomatic Ruby, but
in this case I think that it's very easy to read, and serves well as documentation.