### PR TITLE
The options give a more compact report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - gem install rubocop
 
 script:
-  - rubocop
+  - rubocop -fs -D
   - make test
   - bin/fetch-configlet
   - bin/configlet .


### PR DESCRIPTION
```text
     _- Formatter flag
    / _- Simple Format
   //  _- Display Cop Names
  //  /
-fs -D
```

Gives a report like this:

```text
== Rakefile ==
C:  2: 81: Metrics/LineLength: Line is too long. [90/80]
```