### PR TITLE
Clarify dependency or error.

### DIFF
--- a/hello-world/hello_world_test.rb
+++ b/hello-world/hello_world_test.rb
@@ -4,10 +4,10 @@ begin
   require 'minitest/autorun'
   require_relative 'hello_world'
 rescue Gem::LoadError => e
-  puts "\n\n#{e.backtrace.first} #{e.message}"
+  puts "\nMissing Dependency:\n#{e.backtrace.first} #{e.message}"
   puts 'Minitest 5.0 gem must be installed for the xRuby track.'
 rescue LoadError => e
-  puts "\n\n#{e.backtrace.first} #{e.message}"
+  puts "\nError:\n#{e.backtrace.first} #{e.message}"
   puts DATA.read
   exit 1
 end


### PR DESCRIPTION
For Minitest less than version 5.0.0 the error states "Missing
Dependency" and for the first error, it states "Error" as eluded to in
the message.