### PR TITLE
Allow tests to reveal broken problem examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,8 @@ test-assignment:
 	@echo "----------------------------------------------------------------"
 	@echo "running tests for: $(ASSIGNMENT)"
 	@cp -r $(ASSIGNMENT)/* $(OUTDIR)
-	@cat $(ASSIGNMENT)/$(TSTFILE) | sed '/skip\s*$$/d' > $(OUTDIR)/$(TSTFILE)
 	@cp $(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(SRCFILE).$(FILEEXT)
-	@ruby $(OUTDIR)/$(TSTFILE)
+	@ruby -I./lib -rdisable_skip.rb $(OUTDIR)/$(TSTFILE)
 
 # all tests
 test:

--- a/custom-set/custom_set_test.rb
+++ b/custom-set/custom_set_test.rb
@@ -54,7 +54,7 @@ class CustomSetTest < Minitest::Test
   end
 
   def test_member?
-    skip('No method uniq for Range(1..3)')
+    skip
     assert CustomSet.new([1, 2, 3]).member?(2)
     assert CustomSet.new(1..3).member?(2)
     refute CustomSet.new(1..3).member?(2.0)

--- a/custom-set/example.rb
+++ b/custom-set/example.rb
@@ -2,7 +2,7 @@ class CustomSet
   attr_reader :data
 
   def initialize(input_data = [])
-    @data = parse_data(input_data.uniq)
+    @data = parse_data(input_data.to_a.uniq)
   end
 
   def delete(datum)

--- a/lib/disable_skip.rb
+++ b/lib/disable_skip.rb
@@ -5,7 +5,7 @@ require 'minitest/autorun'
 
 module Minitest
   class Test
-    def skip
+    def skip(_msg='', _bt=caller)
     end
   end
 end


### PR DESCRIPTION
re: #158

This first step is to reveal the skips that are not disabled allowing
bad example code through our checks.

To allow for this, the monkey patch on Skip should adhere to the
contract set forth in `Minitest::Assertions`

The Makefile is now using the same process for disabling skips.