### PR TITLE
No longer drives the solution

### DIFF
--- a/largest-series-product/example.rb
+++ b/largest-series-product/example.rb
@@ -9,7 +9,9 @@ class Series
   def largest_product(length)
     @length = length
     validate_length
-    analyzer
+    return 1 if @digits.empty?
+    collection_of_digits
+    select_max { reduce_to_product  { validate  { separate } } }
   end
 
   private
@@ -17,11 +19,6 @@ class Series
   def validate_length
     @length > digits.length and
       fail(ArgumentError.new 'Not enough digits')
-  end
-
-  def analyzer
-    collection_of_digits
-    select_max { reduce_to_product { validate { separate } } }
   end
 
   def validate

--- a/largest-series-product/example.rb
+++ b/largest-series-product/example.rb
@@ -3,34 +3,37 @@
 class Series
   attr_reader :digits
   def initialize(numeric_string)
-    @digits = convert_to_digits(numeric_string)
+    @digits = numeric_string
   end
 
   def largest_product(length)
-    fail ArgumentError.new('Not enough digits') if length > digits.length
-    products = []
-    slices(length).each do |slice|
-      products << slice.inject(1) do |product, n|
-        product * n
-      end
-    end
-    products.sort.last
-  end
-
-  def slices(length)
-    result = []
-    i = -1
-    begin
-      i += 1
-      i2 = i + length - 1
-      result << digits[i..i2]
-    end while i2 < digits.size - 1
-    result
+    @length = length
+    fail ArgumentError.new('Not enough digits') if @length > digits.length
+    analyzer
   end
 
   private
 
-  def convert_to_digits(s)
-    s.chars.to_a.map(&:to_i)
+  def analyzer
+    collection_of_digits
+    reduce_to_product { validate { separate } }.max
+  end
+
+  def validate
+    yield.take_while { |array| array.size == @length }
+  end
+
+  def reduce_to_product
+    yield.map { |array| array.inject(1, :*) }
+  end
+
+  def separate
+    0.upto(digits.length - 1).map.with_index do |_, index|
+      digits[index, @length]
+    end
+  end
+
+  def collection_of_digits
+    @digits = digits.chars.map(&:to_i)
   end
 end

--- a/largest-series-product/example.rb
+++ b/largest-series-product/example.rb
@@ -8,15 +8,20 @@ class Series
 
   def largest_product(length)
     @length = length
-    fail ArgumentError.new('Not enough digits') if @length > digits.length
+    validate_length
     analyzer
   end
 
   private
 
+  def validate_length
+    @length > digits.length and
+      fail(ArgumentError.new 'Not enough digits')
+  end
+
   def analyzer
     collection_of_digits
-    reduce_to_product { validate { separate } }.max
+    select_max { reduce_to_product { validate { separate } } }
   end
 
   def validate
@@ -27,8 +32,12 @@ class Series
     yield.map { |array| array.inject(1, :*) }
   end
 
+  def select_max
+    yield.max
+  end
+
   def separate
-    0.upto(digits.length - 1).map.with_index do |_, index|
+    digits.map.with_index do |_, index|
       digits[index, @length]
     end
   end

--- a/largest-series-product/largest_series_product_test.rb
+++ b/largest-series-product/largest_series_product_test.rb
@@ -7,18 +7,7 @@ require_relative 'largest_series_product'
 # rubocop:disable Lint/ParenthesesAsGroupedExpression
 #
 class Seriestest < Minitest::Test
-  def test_required_method_called_largest_product
-    assert_respond_to Series.allocate, :largest_product
-  end
-
-  def test_largest_product_of_2
-    skip
-    series = Series.new('0123456789')
-    assert_equal 72, series.largest_product(2)
-  end
-
   def test_largest_product_of_a_tiny_number
-    skip
     series = Series.new('12')
     assert_equal 2, series.largest_product(2)
   end
@@ -27,6 +16,12 @@ class Seriestest < Minitest::Test
     skip
     series = Series.new('19')
     assert_equal 9, series.largest_product(2)
+  end
+
+  def test_largest_product_of_2
+    skip
+    series = Series.new('0123456789')
+    assert_equal 72, series.largest_product(2)
   end
 
   def test_largest_product_of_2_shuffled

--- a/largest-series-product/largest_series_product_test.rb
+++ b/largest-series-product/largest_series_product_test.rb
@@ -5,6 +5,7 @@ require_relative 'largest_series_product'
 
 # Rubocop directives
 # rubocop:disable Lint/ParenthesesAsGroupedExpression
+# rubocop:disable Style/AlignParameters:
 #
 class Seriestest < Minitest::Test
   def test_largest_product_of_a_tiny_number
@@ -21,13 +22,15 @@ class Seriestest < Minitest::Test
   def test_largest_product_of_2
     skip
     series = Series.new('0123456789')
-    assert_equal 72, series.largest_product(2)
+    assert_equal 72, series.largest_product(2),
+      'Largest product of all sets of 2 result from 8 and 9'
   end
 
   def test_largest_product_of_2_shuffled
     skip
     series = Series.new('576802143')
-    assert_equal 48, series.largest_product(2)
+    assert_equal 48, series.largest_product(2),
+      'Largest product of all sets of 2 result from 6 and 8'
   end
 
   def test_largest_product_of_3
@@ -60,6 +63,13 @@ class Seriestest < Minitest::Test
     s = '52677741234314237566414902593461595376319419139427'
     series = Series.new(s)
     assert_equal 28_350, series.largest_product(6)
+  end
+
+  def test_identity
+    skip
+    series = Series.new('')
+    assert_equal 1, series.largest_product(0),
+      'Identity of an empty group is 1'
   end
 
   def test_slices_bigger_than_number

--- a/largest-series-product/largest_series_product_test.rb
+++ b/largest-series-product/largest_series_product_test.rb
@@ -7,56 +7,8 @@ require_relative 'largest_series_product'
 # rubocop:disable Lint/ParenthesesAsGroupedExpression
 #
 class Seriestest < Minitest::Test
-  def test_digits
-    assert_equal (0..9).to_a, Series.new('0123456789').digits
-  end
-
-  def test_same_digits_reversed
-    skip
-    assert_equal (0..9).to_a.reverse, Series.new('9876543210').digits
-  end
-
-  def test_fewer_digits
-    skip
-    assert_equal (4..8).to_a.reverse, Series.new('87654').digits
-  end
-
-  def test_some_other_digits
-    skip
-    assert_equal [9, 3, 6, 9, 2, 3, 4, 6, 8], Series.new('936923468').digits
-  end
-
-  def test_slices_of_zero
-    skip
-    assert_equal [], Series.new('').digits
-  end
-
-  def test_slices_of_2
-    skip
-    series = Series.new('01234')
-    expected = [[0, 1], [1, 2], [2, 3], [3, 4]]
-    assert_equal expected, series.slices(2)
-  end
-
-  def test_other_slices_of_2
-    skip
-    series = Series.new('98273463')
-    expected = [[9, 8], [8, 2], [2, 7], [7, 3], [3, 4], [4, 6], [6, 3]]
-    assert_equal expected, series.slices(2)
-  end
-
-  def test_slices_of_3
-    skip
-    series = Series.new('01234')
-    expected = [[0, 1, 2], [1, 2, 3], [2, 3, 4]]
-    assert_equal expected, series.slices(3)
-  end
-
-  def test_other_slices_of_3
-    skip
-    series = Series.new('982347')
-    expected = [[9, 8, 2], [8, 2, 3], [2, 3, 4], [3, 4, 7]]
-    assert_equal expected, series.slices(3)
+  def test_required_method_called_largest_product
+    assert_respond_to Series.allocate, :largest_product
   end
 
   def test_largest_product_of_2
@@ -113,12 +65,6 @@ class Seriestest < Minitest::Test
     s = '52677741234314237566414902593461595376319419139427'
     series = Series.new(s)
     assert_equal 28_350, series.largest_product(6)
-  end
-
-  def test_identity
-    skip
-    series = Series.new('')
-    assert_equal 1, series.largest_product(0)
   end
 
   def test_slices_bigger_than_number


### PR DESCRIPTION
Does not rely on on any specifically named 'helper' methods.  Tests
things through the implementation via public facing API

re: #10 

I removed the test for "identity" as well, as there was nothing that indicated that a empty string should return 1, which is what the test stated.

The example file was changed against the original specification provided by the README and the tests prior to these changes.