### PR TITLE
Added tests for `VERSION` and for invalid input

### DIFF
--- a/rna-transcription/example.rb
+++ b/rna-transcription/example.rb
@@ -1,4 +1,6 @@
 class Complement
+  VERSION = 1
+
   def self.of_dna(strand)
     DNA.new(strand).tr('CGTA', 'GCAU')
   end

--- a/rna-transcription/rna_transcription_test.rb
+++ b/rna-transcription/rna_transcription_test.rb
@@ -62,4 +62,21 @@ class ComplementTest < Minitest::Test
     skip
     assert_raises(ArgumentError) { Complement.of_rna('T') }
   end
+  
+  def test_rna_raises_argument_error_on_completely_invalid_input
+    skip
+    assert_raises(ArgumentError) { Complement.of_rna('XXX') }
+  end
+  
+  def tes_dna_raises_argument_error_on_completely_invalid_input
+    skip
+    assert_raises(ArgumentError) { Complement.of_dna('XXX') }
+  end
+  
+  # This test is for the sake of people providing feedback, so they
+  # know which version of the exercise you are solving.
+  def test_bookkeeping
+    skip
+    assert_equal 1, Complement::VERSION
+  end
 end

--- a/rna-transcription/rna_transcription_test.rb
+++ b/rna-transcription/rna_transcription_test.rb
@@ -62,17 +62,17 @@ class ComplementTest < Minitest::Test
     skip
     assert_raises(ArgumentError) { Complement.of_rna('T') }
   end
-  
+
   def test_rna_raises_argument_error_on_completely_invalid_input
     skip
     assert_raises(ArgumentError) { Complement.of_rna('XXX') }
   end
-  
+
   def tes_dna_raises_argument_error_on_completely_invalid_input
     skip
     assert_raises(ArgumentError) { Complement.of_dna('XXX') }
   end
-  
+
   # This test is for the sake of people providing feedback, so they
   # know which version of the exercise you are solving.
   def test_bookkeeping


### PR DESCRIPTION
The invalid input that I provide here is not valid in any context, neither as DNA, nor as RNA. Many solutions on exercism.io only cover up an `'U'` in `of_dna` or a `'T'` in `of_rna`.