### PR TITLE
Pin rubocop to a known good version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ rvm:
   - 2.1.2
 
 install:
-  - gem install minitest
-  - gem install rubocop
+  - gem install minitest --no-ri --no-rdoc
+  - gem install rubocop -v 0.31.0 --no-ri --no-rdoc
 
 script:
   - rubocop -fs -D


### PR DESCRIPTION
There were some backwards incompatible changes that caused new offenses to be triggered
on CI, which in turn causes PRs to fail for reasons unrelated to the code they're changing.

I was going to fix the new offenses, but one of them is actually triggered by
a bug in the rubocop library (see https://github.com/bbatsov/rubocop/issues/2116), so this turned
out to require more time than I could spare for it today.