### PR TITLE
Remove unnecessary rubocop disablings

### DIFF
--- a/binary-search-tree/binary_search_tree_test.rb
+++ b/binary-search-tree/binary_search_tree_test.rb
@@ -32,7 +32,6 @@ class BstTest < Minitest::Test
     assert_equal 5, four.right.data
   end
 
-  # rubocop:disable Metrics/AbcSize
   def test_complex_tree # rubocop:disable Metrics/MethodLength
     skip
     four = Bst.new 4

--- a/circular-buffer/circular_buffer_test.rb
+++ b/circular-buffer/circular_buffer_test.rb
@@ -27,7 +27,6 @@ class CircularBufferTest < Minitest::Test
     assert_raises(CircularBuffer::BufferEmptyException) { buffer.read }
   end
 
-  # rubocop:disable Metrics/AbcSize
   def test_clearing_buffer
     skip
     buffer = CircularBuffer.new(3)

--- a/largest-series-product/largest_series_product_test.rb
+++ b/largest-series-product/largest_series_product_test.rb
@@ -4,7 +4,6 @@ require 'minitest/autorun'
 require_relative 'largest_series_product'
 
 # Rubocop directives
-# rubocop:disable Lint/ParenthesesAsGroupedExpression
 # rubocop:disable Style/AlignParameters:
 #
 class Seriestest < Minitest::Test

--- a/linked-list/linked_list_test.rb
+++ b/linked-list/linked_list_test.rb
@@ -39,7 +39,6 @@ class DequeTest < Minitest::Test
     assert_equal 20, deque.pop
   end
 
-  # rubocop:disable Metrics/AbcSize
   def test_example # rubocop:disable Metrics/MethodLength
     skip
     deque = Deque.new

--- a/robot-simulator/robot_simulator_test.rb
+++ b/robot-simulator/robot_simulator_test.rb
@@ -160,7 +160,6 @@ class RobotSimulatorTest < Minitest::Test
     assert_equal :west, robot.bearing
   end
 
-  # rubocop:disable Metrics/AbcSize
   def test_instruct_many_robots # rubocop:disable Metrics/MethodLength
     skip
     robot1 = Robot.new

--- a/simple-linked-list/simple_linked_list_test.rb
+++ b/simple-linked-list/simple_linked_list_test.rb
@@ -12,7 +12,6 @@ class LinkedListTest < Minitest::Test
 
   def test_constructor
     assert_equal 1, @one.datum
-    # rubocop:disable Style/EmptyLines
     assert_nil @one.next
 
     assert_equal 2, @two.datum
@@ -41,7 +40,6 @@ class LinkedListTest < Minitest::Test
     test_constructor
   end
 
-  # rubocop:disable  Metrics/AbcSize
   def test_from_a # rubocop:disable Metrics/MethodLength
     skip
     assert_nil Element.from_a([])


### PR DESCRIPTION
These are some of the warnings that come up if you use a version of rubocop that is higher than 0.31.0.