### PR TITLE
food_chain: An error is raised if File.open or IO.read are used.

### DIFF
--- a/food-chain/example.rb
+++ b/food-chain/example.rb
@@ -1,5 +1,5 @@
 module FoodChain
-  VERSION = 1
+  VERSION = 2
 
   def self.song
     verses(1, 8)

--- a/food-chain/food_chain_test.rb
+++ b/food-chain/food_chain_test.rb
@@ -4,6 +4,36 @@ require 'minitest/autorun'
 
 require_relative 'food_chain'
 
+module NoCheating
+  ERROR_MESSAGE = <<-MSG
+  This exercise intends to help you improve your hability to work
+  with data generated from your code, so DON'T just open or read
+  the song.txt file.
+  MSG
+
+  class File
+    def self.open(*)
+      fail ERROR_MESSAGE
+    end
+  end
+
+  class IO
+    def self.read(*)
+      fail ERROR_MESSAGE
+    end
+  end
+end
+
+if FoodChain.class.eql? Class
+  class FoodChain
+    prepend NoCheating
+  end
+else
+  module FoodChain
+    prepend NoCheating
+  end
+end
+
 class FoodChainTest < Minitest::Test
   # This test is an acceptance test.
   #
@@ -23,6 +53,6 @@ class FoodChainTest < Minitest::Test
   # giving feedback know which version of the exercise you solved.
   def test_version
     skip
-    assert_equal 1, FoodChain::VERSION
+    assert_equal 2, FoodChain::VERSION
   end
 end

--- a/food-chain/food_chain_test.rb
+++ b/food-chain/food_chain_test.rb
@@ -6,7 +6,7 @@ require_relative 'food_chain'
 
 module NoCheating
   ERROR_MESSAGE = <<-MSG
-  This exercise intends to help you improve your hability to work
+  This exercise intends to help you improve your ability to work
   with data generated from your code, so DON'T just open or read
   the song.txt file.
   MSG
@@ -24,15 +24,7 @@ module NoCheating
   end
 end
 
-if FoodChain.class.eql? Class
-  class FoodChain
-    prepend NoCheating
-  end
-else
-  module FoodChain
-    prepend NoCheating
-  end
-end
+FoodChain.prepend NoCheating
 
 class FoodChainTest < Minitest::Test
   # This test is an acceptance test.


### PR DESCRIPTION
This would be the first part to address https://github.com/exercism/xruby/issues/179.

As a lot of people solves the _kata_ by just loading the file `song.txt` with either of `File.open` or `IO.read`, this version of the tests raises run-time error, explaining that the desired solution must be to generate the song verses with the program.

It is left to improve the wording in the [metadata](https://github.com/exercism/x-common/blob/master/food-chain.yml).