### PR TITLE
Add tests to Rna Transcription for partially invalid input.

### DIFF
--- a/rna-transcription/example.rb
+++ b/rna-transcription/example.rb
@@ -1,5 +1,5 @@
 class Complement
-  VERSION = 1
+  VERSION = 2
 
   def self.of_dna(strand)
     DNA.new(strand).tr('CGTA', 'GCAU')

--- a/rna-transcription/rna_transcription_test.rb
+++ b/rna-transcription/rna_transcription_test.rb
@@ -68,15 +68,25 @@ class ComplementTest < Minitest::Test
     assert_raises(ArgumentError) { Complement.of_rna('XXX') }
   end
 
-  def tes_dna_raises_argument_error_on_completely_invalid_input
+  def test_dna_raises_argument_error_on_completely_invalid_input
     skip
     assert_raises(ArgumentError) { Complement.of_dna('XXX') }
+  end
+
+  def test_dna_raises_argument_error_on_partially_invalid_input
+    skip
+    assert_raises(ArgumentError) { Complement.of_dna('ACGTXXXCTTAA') }
+  end
+
+  def test_rna_raises_argument_error_on_partially_invalid_input
+    skip
+    assert_raises(ArgumentError) { Complement.of_rna('UGAAXXXGACAUG') }
   end
 
   # This test is for the sake of people providing feedback, so they
   # know which version of the exercise you are solving.
   def test_bookkeeping
     skip
-    assert_equal 1, Complement::VERSION
+    assert_equal 2, Complement::VERSION
   end
 end


### PR DESCRIPTION
The current test suite checks for an `ArgumentError` on completely invalid input, but not partially invalid input. For example, this solution passes all of the existing tests but accepts input that has a mix of valid and invalid characters:
~~~ruby
class Complement

  DNA_REGEX = /[CGTA]/
  RNA_REGEX = /[CGAU]/

  KEYS = {
    'C' => 'G',
    'G' => 'C',
    'T' => 'A',
    'A' => 'U'
  }

  def self.of_dna(dna)
    raise ArgumentError unless dna.match(DNA_REGEX)
    dna.gsub(DNA_REGEX, KEYS)
  end

  def self.of_rna(rna)
    raise ArgumentError unless rna.match(RNA_REGEX)
    rna.gsub(RNA_REGEX, KEYS.invert)
  end

end
~~~
These additional tests might discourage novices from simply checking for the arguments present in the tests.