### PR TITLE
Add File read for great messages

### DIFF
--- a/food-chain/food_chain_test.rb
+++ b/food-chain/food_chain_test.rb
@@ -49,6 +49,10 @@ module RestrictedClasses
     def self.open(*)
       fail NoCheating
     end
+
+    def self.read(*)
+      fail NoCheating
+    end
   end
 
   class IO


### PR DESCRIPTION
File.read was getting a not so great error message as mentioned in #181 and this adds the File.read to the collection of ways to read a file that should be disallowed nicely.