### PR TITLE
Update RNA_transcription version test comments to be more clear for user

### DIFF
--- a/rna-transcription/rna_transcription_test.rb
+++ b/rna-transcription/rna_transcription_test.rb
@@ -83,8 +83,14 @@ class ComplementTest < Minitest::Test
     assert_raises(ArgumentError) { Complement.of_rna('UGAAXXXGACAUG') }
   end
 
-  # This test is for the sake of people providing feedback, so they
-  # know which version of the exercise you are solving.
+  # Problems in exercism evolve over time,
+  # as we find better ways to ask questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of Complement.
+  # If you're curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
   def test_bookkeeping
     skip
     assert_equal 2, Complement::VERSION


### PR DESCRIPTION
Clarify the comments in the test for the version number so the user knows that they do not need to increment the version number