### PR TITLE
Update gigasecond version test comments to be more clear for user

### DIFF
--- a/gigasecond/gigasecond_test.rb
+++ b/gigasecond/gigasecond_test.rb
@@ -43,8 +43,14 @@ class GigasecondTest < Minitest::Test
     skip
   end
 
-  # This test is for the sake of people providing feedback, so they
-  # know which version of the exercise you are solving.
+  # Problems in exercism evolve over time,
+  # as we find better ways to ask questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of Gigasecond.
+  # If you're curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
   def test_bookkeeping
     assert_equal 1, Gigasecond::VERSION
   end


### PR DESCRIPTION
Found that users were getting confused by the version test and it's purpose. Goal is to make it clear to users that there only need to return the number that is asked. They do not need to bump the versions themselves at any point. We have also included a link to the ruby docs on contstants so if a user is curious at what they are inserting, they can read more about them.