### PR TITLE
Update food-chain version test comments to be more clear for user

### DIFF
--- a/food-chain/food_chain_test.rb
+++ b/food-chain/food_chain_test.rb
@@ -36,8 +36,14 @@ class FoodChainTest < Minitest::Test
     end
   end
 
-  # This is some simple book-keeping to let people who are
-  # giving feedback know which version of the exercise you solved.
+  # Problems in exercism evolve over time,
+  # as we find better ways to ask questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of FoodChain.
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
   def test_version
     skip
     assert_equal 2, FoodChain::VERSION


### PR DESCRIPTION
Found that users were getting confused by the version test and it's purpose (see [ticket 188](https://github.com/exercism/xruby/issues/188)). Goal is to make it clear to users that there only need to return the number that is asked. They do not need to bump the versions themselves at any point. We have also included a link to the ruby docs on contstants so if a user is curious at what they are inserting, they can read more about them