### PR TITLE
Update acronym version test comments to be more clear for user

### DIFF
--- a/acronym/acronym_test.rb
+++ b/acronym/acronym_test.rb
@@ -23,8 +23,14 @@ class AcronymTest < Minitest::Test
     gem 'minitest', '>= 5.0.0'
   end
 
-  # This is some simple book-keeping to let people who are
-  # giving feedback know which version of the exercise you solved.
+  # Problems in exercism evolve over time,
+  # as we find better ways to ask questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of Acronym.
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
   def test_version
     assert_equal 1, Acronym::VERSION
   end


### PR DESCRIPTION
Found that users were getting confused by the version test and it's purpose (see ticket https://github.com/exercism/xruby/issues/188). Goal is to make it clear to users that there only need to return the number that is asked. They do not need to bump the versions themselves at any point. We have also included a link to the ruby docs on contstants so if a user is curious at what they are inserting, they can read more about them