### PR TITLE
Update hamming version test comments to be more clear for user

### DIFF
--- a/hamming/example.tt
+++ b/hamming/example.tt
@@ -12,11 +12,13 @@ class HammingTest < Minitest::Test<% test_cases.each do |test_case| %>
     assert_equal <%= test_case.expected %>, <%= test_case.do %><% end %>
   end
 <% end %>
-  # This test is for the sake of people providing feedback, so they
-  # know which version of the exercise you are solving.
+  # Problems in exercism evolve over time,
+  # as we find better ways to ask questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
   #
   # Define a constant named VERSION inside of Hamming.
-  # If you're curious, read more about constants on RubyDoc:
+  # If you are curious, read more about constants on RubyDoc:
   # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
   def test_bookkeeping
     skip

--- a/hamming/hamming_test.rb
+++ b/hamming/hamming_test.rb
@@ -76,11 +76,13 @@ class HammingTest < Minitest::Test
     assert_raises(ArgumentError) { Hamming.compute('ATA', 'AGTG') }
   end
 
-  # This test is for the sake of people providing feedback, so they
-  # know which version of the exercise you are solving.
+  # Problems in exercism evolve over time,
+  # as we find better ways to ask questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
   #
   # Define a constant named VERSION inside of Hamming.
-  # If you're curious, read more about constants on RubyDoc:
+  # If you are curious, read more about constants on RubyDoc:
   # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
   def test_bookkeeping
     skip


### PR DESCRIPTION
Found that users were getting confused by the version test and it's purpose (see ticket https://github.com/exercism/xruby/issues/188). Goal is to make it clear to users that there only need to return the number that is asked. They do not need to bump the versions themselves at any point. We have also included a link to the ruby docs on contstants so if a user is curious at what they are inserting, they can read more about them.