### PR TITLE
Correct typo in Ruby SETUP instructions

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -9,7 +9,7 @@ terminal window and run the following command to install minitest:
     gem install minitest
 
 If you would like color output, you can `require 'minitest/pride'` in
-the test file, or note the alternative instruction, below, for runnng
+the test file, or note the alternative instruction, below, for running
 the test file.
 
 In order to run the test, you can run the test file from the exercise


### PR DESCRIPTION
I know this is extremely nitpicky, but... 'running' was missing an 'i'.