### PR TITLE
Add refute cases to custom-set equal test

### DIFF
--- a/custom-set/custom_set_test.rb
+++ b/custom-set/custom_set_test.rb
@@ -6,6 +6,9 @@ require_relative 'custom_set'
 class CustomSetTest < Minitest::Test
   def test_equal
     assert_equal CustomSet.new([1, 3]), CustomSet.new([3, 1])
+    refute_equal CustomSet.new([1, 3]), CustomSet.new([3, 1, 5])
+    refute_equal CustomSet.new([1, 3, 5]), CustomSet.new([3, 1])
+    refute_equal CustomSet.new([1, 3]), CustomSet.new([2, 1])
   end
 
   def test_no_duplicates


### PR DESCRIPTION
Adds some counterexamples to the equal test. Since defining equality is part of the solution, some implementations may pass the assert_equal test without really testing for equality (e.g. one implementation I wrote passed the assert_equal test but incorrectly allowed sets to be equal even if one had more elements).