### PR TITLE
Add new test for trinary

### DIFF
--- a/trinary/example.rb
+++ b/trinary/example.rb
@@ -3,6 +3,7 @@ class Trinary
 
   attr_reader :digits
   def initialize(decimal)
+    decimal = '0' unless decimal.match(/^[012]+$/)
     @digits = decimal.reverse.chars.collect(&:to_i)
   end
 

--- a/trinary/trinary_test.rb
+++ b/trinary/trinary_test.rb
@@ -47,4 +47,9 @@ class TrinaryTest < Minitest::Test
     skip
     assert_equal 0, Trinary.new('carrot').to_decimal
   end
+
+  def test_invalid_trinary_with_digits_is_decimal_0
+    skip
+    assert_equal 0, Trinary.new('0a1b2c').to_decimal
+  end
 end


### PR DESCRIPTION
Previously, certain implementations of trinary could pass all of the
tests despite doing no validation on the input. This is because "a".to_i
(and any non-numeric character) is 0 in ruby, so an all alpha test
string will evaluate to 0. This commit adds a string that has numbers
mixed in with letters, to ensure that validation is required for tests
to pass. This also updates the example to do the required validation.