### PR TITLE
Normalize YAML in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
+---
 language: ruby
-
-sudo: false # use containers for faster builds
-
+sudo: false
 rvm:
-  - 2.1.2
-
+- 2.1.2
 install:
-  - gem install minitest --no-ri --no-rdoc
-  - gem install rubocop -v 0.31.0 --no-ri --no-rdoc
-
+- gem install minitest --no-document
+- gem install rubocop -v 0.31.0 --no-document
 script:
-  - rubocop -fs -D
-  - bin/executable-tests-check
-  - make test
-  - bin/fetch-configlet
-  - bin/configlet .
+- rubocop -fs -D
+- bin/executable-tests-check
+- make test
+- bin/fetch-configlet
+- bin/configlet .


### PR DESCRIPTION
The YAML was not quite valid. Travis can read it
and wasn't complaining, but this ensures that the YAML
is clean.