### PR TITLE
RubyLearning DNS has changed

### DIFF
--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -4,7 +4,7 @@ Exercism provides exercises and feedback but can be difficult to jump into for t
 
 * [Ruby in Twenty Minutes](https://www.ruby-lang.org/en/documentation/quickstart/)
 * [Ruby Documentation](http://ruby-doc.org/)
-* [RubyLearning.com](http://www.rubylearning.com/) - Ruby Tutorial and Study Notes
+* [RubyLearning.com](http://rubylearning.com/) - Ruby Tutorial and Study Notes
 * [RubyLearning.org](http://rubylearning.org/classes/) - Professionally Taught and Moderated Classes
 * [Learn to Program](http://pine.fm/LearnToProgram/) - A book (available online) written by Chris Pine
 * [StackOverflow](http://stackoverflow.com/questions/tagged/ruby)


### PR DESCRIPTION
No longer using the `www` prefix for the home page on RubyLearning.com
fixes #230