### PR TITLE
generator: look for files in exercises/ dir

### DIFF
--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -20,7 +20,7 @@ class Generator
   end
 
   def path_to(file)
-    File.expand_path(File.join('..', '..', name, file), __FILE__)
+    File.expand_path(File.join('..', '..', 'exercises', name, file), __FILE__)
   end
 
   def version


### PR DESCRIPTION
In 7ec5c675610fe5981f8894fdd4ff9e61f00da30d all exercises were moved to
the `exercises/` directory. The generator needs to be able to know the
path a given exercise resides at to be able to read the template, write
version files, write the actual test file, etc. So we need to update the
generator to use the new path.

Tested by ensuring that bin/generate-* can be run after this change (it
would not be able to run before this change).

Note however that bin/generate-difference-of-squares wasn't able to run,
but that's a separate issue - the JSON file doesn't contain a top-level
"cases" keys like the generator expects. Instead the "cases" keys are in
"square_of_sum" and "sum_of_squares".