### PR TITLE
Cleanup simple-linked-list

### DIFF
--- a/exercises/simple-linked-list/example.rb
+++ b/exercises/simple-linked-list/example.rb
@@ -1,62 +1,68 @@
 class Element
-  attr_reader :datum
-  attr_reader :next
+  attr_reader   :datum
+  attr_accessor :next
 
-  def self.from_a(arr)
-    arr.reverse_each.inject(NullElement.new) { |memo, obj| new(obj, memo) }
-  end
-
-  def self.each_datum(elem)
-    until elem.nil?
-      yield elem.datum
-      elem = elem.next
-    end
-  end
-
-  def self.to_a(elem)
-    arr = []
-    each_datum(elem, &arr.method(:push))
-    arr
-  end
-
-  def self.reverse(elem)
-    res = nil
-    each_datum(elem) { |datum| res = new(datum, res) }
-    res
-  end
-
-  def initialize(datum, next_element = NullElement.new)
+  def initialize(datum, next_element=nil)
     @datum = datum
-    @next = next_element
+    @next  = next_element
   end
 
-  def to_a
-    self.class.to_a(self)
-  end
-
-  def reverse
-    self.class.reverse(self)
+  def tail?
+    @next.nil?
   end
 end
 
-class NullElement
+class SimpleLinkedList
+  attr_reader :size
+  attr_reader :head
+
+  def initialize
+    @head = nil
+    @size = 0
+  end
+
+  def push(datum)
+    e = Element.new(datum, @head)
+    @head = e
+    @size += 1
+  end
+
+  def empty?
+    @size.zero?
+  end
+
+  def peek
+    @head.nil? ? nil : @head.datum
+  end
+
+  def pop
+    e, @head = @head, @head.next
+    @size -= 1
+    return e.datum
+  end
+
+  def each
+    return enum_for(:each) unless block_given?
+    current = head
+    until current.nil?
+      yield current.datum
+      current = current.next
+    end
+  end
+
   def to_a
-    []
+    each.to_a
   end
 
   def reverse
-    self
+    each.with_object(SimpleLinkedList.new) { |datum, list| list.push(datum) }
   end
 
-  def datum
-    nil
-  end
-
-  def next
-    nil
-  end
-
-  def nil?
-    true
+  def self.from_a(a)
+    new.tap do |list|
+      a.to_a.reverse_each do |item|
+        list.push(item)
+      end
+    end
   end
 end

--- a/exercises/simple-linked-list/simple_linked_list_test.rb
+++ b/exercises/simple-linked-list/simple_linked_list_test.rb
@@ -5,69 +5,185 @@ require 'minitest/autorun'
 require_relative 'simple_linked_list'
 
 class LinkedListTest < Minitest::Test
-  def setup
-    @one = Element.new(1, nil)
-    @two = Element.new(2, @one)
+  def test_element_datum
+    e = Element.new(1)
+    assert_equal 1, e.datum
   end
 
-  def test_constructor
-    assert_equal 1, @one.datum
-    assert_nil @one.next
-
-    assert_equal 2, @two.datum
-    assert_same @one, @two.next
-  end
-
-  def test_to_a
+  def test_element_tail
     skip
-    assert_equal [], Element.to_a(nil)
-    assert_equal [1], Element.to_a(@one)
-    assert_equal [2, 1], Element.to_a(@two)
+    e = Element.new(1)
+    assert e.tail?
   end
 
-  def test_reverse
+  def test_element_next_default
     skip
-    # one_r and @one need not be the same object
-    one_r = @one.reverse
-    assert_equal 1, one_r.datum
-    assert_nil one_r.next
-
-    two_r = @two.reverse
-    assert_equal 1, two_r.datum
-    assert_equal 2, two_r.next.datum
-
-    # ensure that nothing changed about the given objects
-    test_constructor
+    e = Element.new(1)
+    assert_nil e.next
   end
 
-  def test_from_a # rubocop:disable Metrics/MethodLength
+  def test_element_next_initialization
     skip
-    assert_nil Element.from_a([])
-
-    one_a = Element.from_a([1])
-    assert_equal 1, one_a.datum
-    assert_nil one_a.next
-
-    two_a = Element.from_a([2, 1])
-    assert_equal 2, two_a.datum
-    assert_equal 1, two_a.next.datum
-    assert_nil two_a.next.next
-
-    one_to_ten = Element.from_a(1..10)
-    assert_equal 10,
-                 one_to_ten.next.next.next.next.next.next.next.next.next.datum
+    e1 = Element.new(1)
+    e2 = Element.new(2, e1)
+    assert_equal e1, e2.next
   end
 
-  def test_roundtrip
+  def test_empty_list_size
     skip
-    assert_equal [1], Element.from_a([1]).to_a
-    assert_equal [2, 1], Element.from_a([2, 1]).to_a
-    assert_equal (1..10).to_a, Element.from_a(1..10).to_a
+    l = SimpleLinkedList.new
+    assert_equal 0, l.size
   end
 
-  def test_empty_list_operations
+  def test_empty_list_empty
     skip
-    assert_equal [], Element.from_a([]).to_a
-    assert_equal [], Element.from_a([]).reverse.to_a
+    l = SimpleLinkedList.new
+    assert l.empty?
+  end
+
+  def test_pushing_element_on_list
+    skip
+    l = SimpleLinkedList.new
+    l.push(1)
+    assert_equal 1, l.size
+  end
+
+  def test_empty_list_1_element
+    skip
+    l = SimpleLinkedList.new
+    l.push(1)
+    refute l.empty?
+  end
+
+  def test_peeking_at_list
+    skip
+    l = SimpleLinkedList.new
+    l.push(1)
+    assert_equal 1, l.size
+    assert_equal 1, l.peek
+  end
+
+  def test_peeking_at_empty_list
+    skip
+    l = SimpleLinkedList.new
+    assert_nil l.peek
+  end
+
+  def test_access_head_element
+    skip
+    l = SimpleLinkedList.new
+    l.push(1)
+    assert_instance_of Element, l.head
+    assert_equal 1, l.head.datum
+    assert l.head.tail?
+  end
+
+  def test_items_are_stacked
+    skip
+    l = SimpleLinkedList.new
+    l.push(1)
+    l.push(2)
+    assert_equal 2, l.size
+    assert_equal 2, l.head.datum
+    assert_equal 1, l.head.next.datum
+  end
+
+  def test_push_10_items
+    skip
+    l = SimpleLinkedList.new
+    (1..10).each do |datum|
+      l.push(datum)
+    end
+    assert_equal 10, l.size
+    assert_equal 10, l.peek
+  end
+
+  def test_pop_1_item
+    skip
+    l = SimpleLinkedList.new
+    l.push(1)
+    assert_equal 1, l.pop
+    assert_equal 0, l.size
+  end
+
+  def test_popping_frenzy
+    skip
+    l = SimpleLinkedList.new
+    (1..10).each do |datum|
+      l.push(datum)
+    end
+    6.times { l.pop }
+    assert_equal 4, l.size
+    assert_equal 4, l.peek
+  end
+
+  def test_from_a_empty_array
+    skip
+    l = SimpleLinkedList.from_a([])
+    assert_equal 0, l.size
+    assert_nil l.peek
+  end
+
+  def test_from_a_nil
+    skip
+    l = SimpleLinkedList.from_a(nil)
+    assert_equal 0, l.size
+    assert_nil l.peek
+  end
+
+  def test_from_a_2_element_array
+    skip
+    l = SimpleLinkedList.from_a([1, 2])
+    assert_equal 2, l.size
+    assert_equal 1, l.peek
+    assert_equal 2, l.head.next.datum
+  end
+
+  def test_from_a_10_items
+    skip
+    l = SimpleLinkedList.from_a((1..10).to_a)
+    assert_equal 10, l.size
+    assert_equal 1, l.peek
+    assert_equal 10, l.head.next.next.next.next.next.next.next.next.next.datum
+  end
+
+  def test_to_a_empty_list
+    skip
+    l = SimpleLinkedList.new
+    assert_equal [], l.to_a
+  end
+
+  def test_to_a_of_1_element_list
+    skip
+    assert_equal [1], SimpleLinkedList.from_a([1]).to_a
+  end
+
+  def test_to_a_of_2_element_list
+    skip
+    assert_equal [1, 2], SimpleLinkedList.from_a([1, 2]).to_a
+  end
+
+  def test_reverse_2_element_list
+    skip
+    list = SimpleLinkedList.from_a([1, 2])
+    # list_r and list need not be the same object
+    list_r = list.reverse
+
+    assert_equal 2, list_r.peek
+    assert_equal 1, list_r.head.next.datum
+    assert list_r.head.next.tail?
+  end
+
+  def test_reverse_10_element_list
+    skip
+    data = (1..10).to_a
+    list = SimpleLinkedList.from_a(data)
+    assert_equal data.reverse, list.reverse.to_a
+  end
+
+  def test_roundtrip_10_element_array
+    skip
+    data = (1..10).to_a
+    assert_equal data, SimpleLinkedList.from_a(data).to_a
   end
 end


### PR DESCRIPTION
This is an update to simple linked list to address the issues in #249.

Changes:
* We do not test reversing a list created from an empty array since `Element.from_a([]) # => nil`
* We stop testing `Element#next` for nil and start testing `Element#tail?`
* Split all the tests up into separate methods since previously many things were being tested in each test method.
* In the example we no longer need to use a NullObject pattern.

closes #249 

