### PR TITLE
Add Binary test to account for when string has a space

### DIFF
--- a/exercises/binary/binary_test.rb
+++ b/exercises/binary/binary_test.rb
@@ -49,7 +49,7 @@ class BinaryTest < Minitest::Test
 
   def test_invalid_binary_numbers_raise_an_error
     skip
-    %w(012 10nope nope10).each do |input|
+    %w(012 10nope nope10 001\ nope).each do |input|
       assert_raises ArgumentError do
         Binary.new(input)
       end
@@ -66,6 +66,6 @@ class BinaryTest < Minitest::Test
   # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
   def test_bookkeeping
     skip
-    assert_equal 1, Binary::VERSION
+    assert_equal 2, Binary::VERSION
   end
 end


### PR DESCRIPTION
* Right now in `test_invalid_binary_numbers_raise_an_error` there is no
  check for if the string passed in has a space and then invalid binary. i.e. `"001 yolo"`.
  
* The problem with this is that values that should be failing can pass
  in someones code. For Example if someone was to use the regex
  `/\b[01]+\b/` to validate the binary and the binary passed in was "001
  yolo" it would still match 001 and not raise an error. This commit
  just adds in the case where `"001 yolo"` is passed in to make sure it
  raises an argument error still.