### PR TITLE
Fix tests for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # assignments
 ASSIGNMENT ?= ""
 IGNOREDIRS := "^(\.git|bin|docs|lib|exercises)$$"
-ASSIGNMENTS = $(shell find . -maxdepth 1 -mindepth 1 -type d | awk -F/ '{print $$NF}' | sort | grep -Ev $(IGNOREDIRS))
+ASSIGNMENTS = $(shell find ./exercises -maxdepth 1 -mindepth 1 -type d | awk -F/ '{print $$NF}' | sort | grep -Ev $(IGNOREDIRS))
 
 default: test
 
@@ -21,8 +21,8 @@ test-assignment:
 	@echo ""
 	@echo "----------------------------------------------------------------"
 	@echo "running tests for: $(ASSIGNMENT)"
-	@cp -r $(ASSIGNMENT)/* $(OUTDIR)
-	@cp $(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(SRCFILE).$(FILEEXT)
+	@cp -r ./exercises/$(ASSIGNMENT)/* $(OUTDIR)
+	@cp ./exercises/$(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(SRCFILE).$(FILEEXT)
 	@ruby -I./lib -rdisable_skip.rb $(OUTDIR)/$(TSTFILE)
 	@rm -rf $(OUTDIR)
 

--- a/exercises/binary/example.rb
+++ b/exercises/binary/example.rb
@@ -1,5 +1,5 @@
 class Binary
-  VERSION = 1
+  VERSION = 2
 
   attr_reader :digits
   def initialize(s)

--- a/exercises/difference-of-squares/example.rb
+++ b/exercises/difference-of-squares/example.rb
@@ -6,7 +6,7 @@ class Squares
     @max = max
   end
 
-  def square_of_sums
+  def square_of_sum
     sum = 0
     (1..max).each do |i|
       sum += i
@@ -23,6 +23,6 @@ class Squares
   end
 
   def difference
-    square_of_sums - sum_of_squares
+    square_of_sum - sum_of_squares
   end
 end

--- a/exercises/say/example.rb
+++ b/exercises/say/example.rb
@@ -22,11 +22,10 @@ class Chunk
 
   def say_double_digits
     return '' if double_digits.zero?
-    s = ''
+    s = ' '
     if double_digits < 20
       s << small_numbers[double_digits]
     else
-      s << ' '
       s << decades[tens]
       unless ones.zero?
         s << '-'


### PR DESCRIPTION
The makefile had not been updated to run the files under their new /exercises
subdirectory.

As a result, we had example files that were failing the tests, but CI was passing.

This also fixes the exercises that were failing (binary, difference-of-squares, say).

See https://github.com/exercism/xruby/pull/277