### PR TITLE
file mode changes

### DIFF
--- a/bin/enable-executable
+++ b/bin/enable-executable
@@ -1,12 +1,15 @@
 #!/usr/bin/env ruby
+
+require 'fileutils'
+
 puts 'Ensuring test files are executable...'
 
-Dir.glob('**/*test.rb').each do |f|
+(Dir.glob('**/*test.rb') + Dir.glob('bin/*')).each do |f|
   if File.executable?(f)
     print '.'
   else
-    print "Adding exec bit to #{f}."
-    File.chmod(0744, f)
+    print "\nAdding exec bit to #{f}"
+    FileUtils.chmod('u+x', f)
   end
 end
 puts

--- a/bin/executable-tests-check
+++ b/bin/executable-tests-check
@@ -1,8 +1,7 @@
 #!/usr/bin/env ruby
 require 'minitest/autorun'
 
-files = Dir.glob('**/*_test.rb')
-files.each do |f|
+(Dir.glob('**/*test.rb') + Dir.glob('bin/*')).each do |f|
   describe f do
     it 'should have the execution bit set' do
       assert File.executable?(f), "Execution bit not set for #{f}"


### PR DESCRIPTION
add bin/* files to `enable-executable` and `executable-status-check`
generator now makes test files executable
make `enable-executable` chmod consistent with current file modes