### PR TITLE
specify utf-8 enconding for pangram exercise

### DIFF
--- a/exercises/pangram/example.tt
+++ b/exercises/pangram/example.tt
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# encoding: utf-8
 gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'pangram'

--- a/exercises/pangram/pangram_test.rb
+++ b/exercises/pangram/pangram_test.rb
@@ -1,10 +1,11 @@
 #!/usr/bin/env ruby
+# encoding: utf-8
 gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'pangram'
 
 # Test data version:
-# 180638f Merge pull request #217 from ErikSchierboom/patch-2
+# eb8d142 Merge pull request #220 from IanWhitney/sieve_ordering
 
 class PangramTest < Minitest::Test
   def test_sentence_empty


### PR DESCRIPTION
This should fix an issue @callahat reported in ruby 1.9.3.

A `grep --color=auto --exclude-dir=.git -nrP [^[:ascii:]]` finds this:
```
docs/ABOUT.md:3:Ruby was created as a language of careful balance. Its creator, [Yukihiro “Matz” Matsumoto](https://en.wikipedia.org/wiki/Yukihiro_Matsumoto), blended parts of his favorite languages (Perl, Smalltalk, Eiffel, Ada, and Lisp) to form a new language that balanced functional programming with imperative programming.
README.md:46:├── x-common
README.md:47:└── xruby
exercises/pangram/pangram_test.rb:36:    str = 'Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.'
```

This exercise is the only non-ascii character present in a ruby file.