### PR TITLE
binary: Add invalid edge case tests. Closes #275

### DIFF
--- a/exercises/binary/binary_test.rb
+++ b/exercises/binary/binary_test.rb
@@ -49,7 +49,7 @@ class BinaryTest < Minitest::Test
 
   def test_invalid_binary_numbers_raise_an_error
     skip
-    %w(012 10nope nope10 001\ nope).each do |input|
+    %w(012 10nope nope10 10nope10 001\ nope 2).each do |input|
       assert_raises ArgumentError do
         Binary.new(input)
       end


### PR DESCRIPTION
This is my first contribution (yay!) closing issue #275.

Some of the edge cases mentioned in the issue were already present, so I just added alphabet characters in the middle of a valid binary number (`10nope10`) and an invalid number on its own (`2`).