### PR TITLE
Restricted use of File.read in class name scope

### DIFF
--- a/exercises/food-chain/food_chain_test.rb
+++ b/exercises/food-chain/food_chain_test.rb
@@ -31,7 +31,8 @@ class FoodChainTest < Minitest::Test
   # Tests that an error is effectively raised when IO.read or
   # File.open are used within FoodChain.
   def test_read_guard
-    ["IO.read 'song.txt'", "File.open 'song.txt'"].each do |trigger|
+    song_file = File.expand_path('../song.txt', __FILE__)
+    ["IO.read '#{song_file}'", "File.open '#{song_file}'"].each do |trigger|
       assert_raises(NoCheating) { FoodChain.send :class_eval, trigger }
     end
   end
@@ -59,10 +60,22 @@ module RestrictedClasses
     def self.read(*)
       fail NoCheating
     end
+
+    def open(*)
+      fail NoCheating
+    end
+
+    def read(*)
+      fail NoCheating
+    end
   end
 
   class IO
     def self.read(*)
+      fail NoCheating
+    end
+
+    def read(*)
       fail NoCheating
     end
   end


### PR DESCRIPTION
This restricts use of IO.read and File.read in class- and instance of
class- name space for FoodChain class.