### PR TITLE
Binary Search Tree requires enumerator

### DIFF
--- a/binary-search-tree/binary_search_tree_test.rb
+++ b/binary-search-tree/binary_search_tree_test.rb
@@ -122,6 +122,6 @@ class BstTest < Minitest::Test
   # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
   def test_bookkeeping
     skip
-    assert_equal 2, Bst::VERSION
+    assert_equal 1, Bst::VERSION
   end
 end

--- a/binary-search-tree/binary_search_tree_test.rb
+++ b/binary-search-tree/binary_search_tree_test.rb
@@ -111,4 +111,17 @@ class BstTest < Minitest::Test
     
     assert_raises(StopIteration) { each_enumerator.next }
   end
+  
+  # Problems in exercism evolve over time,
+  # as we find better ways to ask questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of Bst.
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+  def test_bookkeeping
+    skip
+    assert_equal 2, Bst::VERSION
+  end
 end

--- a/binary-search-tree/binary_search_tree_test.rb
+++ b/binary-search-tree/binary_search_tree_test.rb
@@ -86,4 +86,29 @@ class BstTest < Minitest::Test
     four.insert 5
     assert_equal [1, 2, 3, 4, 5, 6, 7], record_all_data(four)
   end
+  
+  def test_each_returns_an_enumerator_if_no_block
+    skip
+    tree = Bst.new(4)
+    tree.insert 2
+    tree.insert 1
+    tree.insert 3
+    tree.insert 6
+    tree.insert 7
+    tree.insert 5
+    
+    each_enumerator = tree.each
+    
+    assert_kind_of Enumerator, each_enumerator
+    
+    assert_equal 1, each_enumerator.next
+    assert_equal 2, each_enumerator.next
+    assert_equal 3, each_enumerator.next
+    assert_equal 4, each_enumerator.next
+    assert_equal 5, each_enumerator.next
+    assert_equal 6, each_enumerator.next
+    assert_equal 7, each_enumerator.next
+    
+    assert_raises(StopIteration) { each_enumerator.next }
+  end
 end

--- a/binary-search-tree/example.rb
+++ b/binary-search-tree/example.rb
@@ -1,5 +1,5 @@
 class Bst
-  VERSION = 2
+  VERSION = 1
   
   attr_reader :data, :left, :right
   def initialize(data)

--- a/binary-search-tree/example.rb
+++ b/binary-search-tree/example.rb
@@ -1,4 +1,6 @@
 class Bst
+  VERSION = 2
+  
   attr_reader :data, :left, :right
   def initialize(data)
     @data = data

--- a/binary-search-tree/example.rb
+++ b/binary-search-tree/example.rb
@@ -2,6 +2,7 @@ class Bst
   attr_reader :data, :left, :right
   def initialize(data)
     @data = data
+    @size = 1
   end
 
   def insert(value)
@@ -10,9 +11,13 @@ class Bst
     else
       insert_right(value)
     end
+    
+    @size += 1
   end
 
   def each(&block)
+    return enum_for(:each) { @size } unless block_given?
+    
     left && left.each(&block)
     block.call(data)
     right && right.each(&block)


### PR DESCRIPTION
In the Ruby core classes `#each` returns an `Enumerator` to itself if it has not gottten a block to work on.

I added a test that requires this and updated the example to work with the new tests.

Added a version constant for the tests.