### PR TITLE
Updated tests and example for Bst

### DIFF
--- a/exercises/binary-search-tree/binary_search_tree_test.rb
+++ b/exercises/binary-search-tree/binary_search_tree_test.rb
@@ -86,4 +86,31 @@ class BstTest < Minitest::Test
     four.insert 5
     assert_equal [1, 2, 3, 4, 5, 6, 7], record_all_data(four)
   end
+
+  def test_each_returns_enumerator_if_no_block
+    skip
+
+    tree = Bst.new 4
+    [2, 1, 3, 6, 7, 5].each { |x| tree.insert x }
+    each_enumerator = tree.each
+
+    assert_kind_of Enumerator, each_enumerator
+
+    (1..7).each { |x| assert_equal(x, each_enumerator.next) }
+
+    assert_raises(StopIteration) { each_enumerator.next }
+  end
+
+  # Problems in exercism evolve over time,
+  # as we find better ways to ask questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of Bst.
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+  def test_bookkeeping
+    skip
+    assert_equal 1, Bst::VERSION
+  end
 end

--- a/exercises/binary-search-tree/example.rb
+++ b/exercises/binary-search-tree/example.rb
@@ -1,7 +1,10 @@
 class Bst
+  VERSION = 1
+
   attr_reader :data, :left, :right
   def initialize(data)
     @data = data
+    @size = 1
   end
 
   def insert(value)
@@ -10,11 +13,15 @@ class Bst
     else
       insert_right(value)
     end
+
+    @size += 1
   end
 
   def each(&block)
+    return enum_for(:each) { @size } unless block_given?
+
     left && left.each(&block)
-    block.call(data)
+    yield
     right && right.each(&block)
   end
 


### PR DESCRIPTION
`Bst#each` should return an enumerator if it doesn't get a block.
Added a test to ensure that it does and that the returned enumerator
behaves properly.

Added a version constant for the tests.

Updated `example.rb` to pass the updated tests.