### PR TITLE
Robot-Name: Better error message on test failure.

### DIFF
--- a/exercises/robot-name/robot_name_test.rb
+++ b/exercises/robot-name/robot_name_test.rb
@@ -40,7 +40,7 @@ class RobotTest < Minitest::Test
     name = robot.name
     robot.reset
     name2 = robot.name
-    assert name != name2
+    refute_equal name, name2
     assert_equal name2, robot.name, COMMAND_QUERY
     assert_match NAME_REGEXP, name2
   end


### PR DESCRIPTION
Use refute_equal (rather than assert !=) in order to return a more helpful error message on test failure.