### PR TITLE
Fix the two-bucket version generation

### DIFF
--- a/exercises/two-bucket/example.tt
+++ b/exercises/two-bucket/example.tt
@@ -14,6 +14,6 @@ class TwoBucketTest < Minitest::Test<% test_cases.each do |test_case| %>
   # Don't forget to define a constant VERSION inside of TwoBucket
   def test_bookkeeping
     skip
-    assert_equal 1, TwoBucket::VERSION
+    assert_equal <%= version + 1 %>, TwoBucket::VERSION
   end
 end


### PR DESCRIPTION
I noticed this after reading @kotp's [comment on #312](https://github.com/exercism/xruby/pull/312#issuecomment-220376215)