### PR TITLE
Leap generator fix

### DIFF
--- a/exercises/leap/example.tt
+++ b/exercises/leap/example.tt
@@ -17,8 +17,8 @@ end
 class YearTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %><% if test_case.expected%>
-    assert <%= test_case.do %>, "<%= test_case.msg%>"<% else %>
-    refute <%= test_case.do %>, "<%= test_case.msg%>"<% end%>
+    assert <%= test_case.do %>, "<%= test_case.failure_message%>"<% else %>
+    refute <%= test_case.do %>, "<%= test_case.failure_message%>"<% end%>
   end
 <% end %>
   # Problems in exercism evolve over time,

--- a/exercises/leap/example.tt
+++ b/exercises/leap/example.tt
@@ -17,8 +17,8 @@ end
 class YearTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %><% if test_case.expected%>
-    assert <%= test_case.do %>, '<%= test_case.msg%>'<% else %>
-    refute <%= test_case.do %>, '<%= test_case.msg%>'<% end%>
+    assert <%= test_case.do %>, "<%= test_case.msg%>"<% else %>
+    refute <%= test_case.do %>, "<%= test_case.msg%>"<% end%>
   end
 <% end %>
   # Problems in exercism evolve over time,

--- a/lib/leap_cases.rb
+++ b/lib/leap_cases.rb
@@ -11,7 +11,7 @@ class LeapCase < OpenStruct
     index > 0
   end
 
-  def msg
+  def failure_message
     "Expected '#{expected}', #{input} is #{expected ? '' : 'not '}a leap year."
   end
 end

--- a/lib/leap_cases.rb
+++ b/lib/leap_cases.rb
@@ -10,6 +10,10 @@ class LeapCase < OpenStruct
   def skipped?
     index > 0
   end
+
+  def msg
+    "Expected '#{expected}', #{input} is #{expected ? '' : 'not '}a leap year."
+  end
 end
 
 LeapCases = proc do |data|


### PR DESCRIPTION
There was no failure message supplied by the test case generator, so all tests had a blank failure message.

This patch adds an informative failure message for each test based on the test input and expected values.

Fixes: #366 