### PR TITLE
Generator: Remove commit message subject from git version indicator.

### DIFF
--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -28,7 +28,7 @@ class Generator
   end
 
   def sha1
-    `cd #{metadata_dir} && git log -1 --oneline`
+    `cd #{metadata_dir} && git log -1 --pretty=format:"%h"`
   end
 
   def test_cases


### PR DESCRIPTION
#### Summary: 
Change git log format from 'oneline' `"%h %s"`, to abbreviated hash only `"%h"`

#### Reasoning:  
The code for generated tests often includes a comment giving the git version of the test data from which the test was generated, such as:  
`# deb225e Implement canonical dataset for scrabble-score problem (#255)`

The same version string is used for all tests generated at that time and will often have no relevance to the test you are looking at and only adds confusion.

"Why is it telling me about scrabble-score? This is the test file for hamming!"

By including only the hash, anyone interested enough in the commit can easily look up the exact commit message and everybody else can just ignore what appears to be a random hexadecimal string.