### PR TITLE
Leap: Add failure messages to tests

### DIFF
--- a/exercises/leap/example.tt
+++ b/exercises/leap/example.tt
@@ -10,8 +10,8 @@ class Date
     throw "Implement this yourself instead of using Ruby's implementation."
   end
 
-  alias_method :gregorian_leap?, :leap?
-  alias_method :julian_leap?, :leap?
+  alias gregorian_leap? leap?
+  alias julian_leap? leap?
 end
 
 class YearTest < Minitest::Test<% test_cases.each do |test_case| %>

--- a/exercises/leap/leap_test.rb
+++ b/exercises/leap/leap_test.rb
@@ -4,8 +4,7 @@ require 'minitest/autorun'
 require_relative 'leap'
 
 # Test data version:
-# deb225e Implement canonical dataset for scrabble-score problem (#255)
-
+# 9b8b80c
 class Date
   def leap?
     throw "Implement this yourself instead of using Ruby's implementation."
@@ -17,37 +16,37 @@ end
 
 class YearTest < Minitest::Test
   def test_leap_year
-    assert Year.leap?(1996), ''
+    assert Year.leap?(1996), "Expected 'true', 1996 is a leap year."
   end
 
   def test_standard_and_odd_year
     skip
-    refute Year.leap?(1997), ''
+    refute Year.leap?(1997), "Expected 'false', 1997 is not a leap year."
   end
 
   def test_standard_even_year
     skip
-    refute Year.leap?(1998), ''
+    refute Year.leap?(1998), "Expected 'false', 1998 is not a leap year."
   end
 
   def test_standard_nineteenth_century
     skip
-    refute Year.leap?(1900), ''
+    refute Year.leap?(1900), "Expected 'false', 1900 is not a leap year."
   end
 
   def test_standard_eighteenth_century
     skip
-    refute Year.leap?(1800), ''
+    refute Year.leap?(1800), "Expected 'false', 1800 is not a leap year."
   end
 
   def test_leap_twenty_fourth_century
     skip
-    assert Year.leap?(2400), ''
+    assert Year.leap?(2400), "Expected 'true', 2400 is a leap year."
   end
 
   def test_leap_y2k
     skip
-    assert Year.leap?(2000), ''
+    assert Year.leap?(2000), "Expected 'true', 2000 is a leap year."
   end
 
   # Problems in exercism evolve over time, as we find better ways to ask
@@ -56,8 +55,9 @@ class YearTest < Minitest::Test
   # not your solution.
   #
   # Define a constant named VERSION inside of the top level BookKeeping
-  # module.
-  #  In your file, it will look like this:
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
   #
   # module BookKeeping
   #   VERSION = 1 # Where the version number matches the one in the test.


### PR DESCRIPTION
Regenerated the leap tests to add in the test failure error messages.

Since the tests themselves have not changed the BookKeeping version number has not been incremented.

Actually fixes #366 (#367 fixed the generator but did not include the updated test file.)
