### PR TITLE
Fix 'require_relative' directive in perfect_numbers_test.rb

### DIFF
--- a/exercises/perfect-numbers/perfect_numbers_test.rb
+++ b/exercises/perfect-numbers/perfect_numbers_test.rb
@@ -1,6 +1,6 @@
 gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
-require_relative 'example'
+require_relative 'perfect_numbers'
 
 class PerfectNumberTest < Minitest::Test
   def test_initialize_perfect_number


### PR DESCRIPTION
`require_relative 'example'` is in `perfect_numbers_test.rb`.

It should be `require_relative 'perfect_numbers'`.