### PR TITLE
Fix Gigasecond test failure messages.

### DIFF
--- a/exercises/gigasecond/example.tt
+++ b/exercises/gigasecond/example.tt
@@ -3,20 +3,20 @@ require 'date'
 require 'time'
 require_relative 'gigasecond'
 
-# Test data version:
-# <%= sha1 %>
+# Test data version: <%= sha1 %>
+
 class GigasecondTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %>
-    gs = Gigasecond.from(<%= test_case.got %>)
-    assert_equal <%= test_case.want %>, gs,
-                 '<%= test_case.msg %>'
+    result = Gigasecond.from(<%= test_case.got %>)
+    assert_equal <%= test_case.want %>, result
   end
 <% end %>
   # Test your 1Gs anniversary
   def test_with_your_birthday
     skip
   end
+
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     assert_equal <%= version.next %>, BookKeeping::VERSION

--- a/exercises/gigasecond/gigasecond_test.rb
+++ b/exercises/gigasecond/gigasecond_test.rb
@@ -3,56 +3,52 @@ require 'date'
 require 'time'
 require_relative 'gigasecond'
 
-# Test data version:
-# deb225e Implement canonical dataset for scrabble-score problem (#255)
+# Test data version: 9b8b80c
 
 class GigasecondTest < Minitest::Test
   def test_2011_04_25
-    gs = Gigasecond.from(Time.utc(2011, 4, 25, 0, 0, 0))
-    assert_equal Time.utc(2043, 1, 1, 1, 46, 40), gs,
-                 ''
+    result = Gigasecond.from(Time.utc(2011, 4, 25, 0, 0, 0))
+    assert_equal Time.utc(2043, 1, 1, 1, 46, 40), result
   end
 
   def test_1977_06_13
     skip
-    gs = Gigasecond.from(Time.utc(1977, 6, 13, 0, 0, 0))
-    assert_equal Time.utc(2009, 2, 19, 1, 46, 40), gs,
-                 ''
+    result = Gigasecond.from(Time.utc(1977, 6, 13, 0, 0, 0))
+    assert_equal Time.utc(2009, 2, 19, 1, 46, 40), result
   end
 
   def test_1959_07_19
     skip
-    gs = Gigasecond.from(Time.utc(1959, 7, 19, 0, 0, 0))
-    assert_equal Time.utc(1991, 3, 27, 1, 46, 40), gs,
-                 ''
+    result = Gigasecond.from(Time.utc(1959, 7, 19, 0, 0, 0))
+    assert_equal Time.utc(1991, 3, 27, 1, 46, 40), result
   end
 
   def test_full_time_specified
     skip
-    gs = Gigasecond.from(Time.utc(2015, 1, 24, 22, 0, 0))
-    assert_equal Time.utc(2046, 10, 2, 23, 46, 40), gs,
-                 ''
+    result = Gigasecond.from(Time.utc(2015, 1, 24, 22, 0, 0))
+    assert_equal Time.utc(2046, 10, 2, 23, 46, 40), result
   end
 
   def test_full_time_with_day_roll_over
     skip
-    gs = Gigasecond.from(Time.utc(2015, 1, 24, 23, 59, 59))
-    assert_equal Time.utc(2046, 10, 3, 1, 46, 39), gs,
-                 ''
+    result = Gigasecond.from(Time.utc(2015, 1, 24, 23, 59, 59))
+    assert_equal Time.utc(2046, 10, 3, 1, 46, 39), result
   end
 
   # Test your 1Gs anniversary
   def test_with_your_birthday
     skip
   end
+
   # Problems in exercism evolve over time, as we find better ways to ask
   # questions.
   # The version number refers to the version of the problem you solved,
   # not your solution.
   #
   # Define a constant named VERSION inside of the top level BookKeeping
-  # module.
-  #  In your file, it will look like this:
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
   #
   # module BookKeeping
   #   VERSION = 1 # Where the version number matches the one in the test.


### PR DESCRIPTION
bin/generate-gigasecond was generating empty test failure messages.

In this case the default messages are fine so I have removed from the template the .msg method calls which were returning the empty strings.

Regenerated the gigasecond_test.rb file WITHOUT incrementing the version number.