### PR TITLE
Trinary: Test for 4, as invalid trinary value

### DIFF
--- a/exercises/trinary/example.rb
+++ b/exercises/trinary/example.rb
@@ -3,7 +3,7 @@ class Trinary
 
   attr_reader :digits
   def initialize(decimal)
-    decimal = '0' unless decimal.match(/^[012]+$/)
+    decimal = '0' unless decimal.match(/\A[012]+\z/)
     @digits = decimal.reverse.chars.collect(&:to_i)
   end
 

--- a/exercises/trinary/example.rb
+++ b/exercises/trinary/example.rb
@@ -15,3 +15,7 @@ class Trinary
     decimal
   end
 end
+
+module BookKeeping
+  VERSION = 1
+end

--- a/exercises/trinary/trinary_test.rb
+++ b/exercises/trinary/trinary_test.rb
@@ -57,4 +57,28 @@ class TrinaryTest < Minitest::Test
     skip
     assert_equal 0, Trinary.new("Invalid\n201\nString").to_decimal
   end
+
+  def test_number_out_of_range
+    skip
+    assert_equal 0, Trinary.new('4').to_decimal
+  end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module.
+  #  In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.htm
+  def test_bookkeeping
+    assert_equal 1, BookKeeping::VERSION
+  end
 end

--- a/exercises/trinary/trinary_test.rb
+++ b/exercises/trinary/trinary_test.rb
@@ -52,4 +52,9 @@ class TrinaryTest < Minitest::Test
     skip
     assert_equal 0, Trinary.new('0a1b2c').to_decimal
   end
+
+  def test_invalid_trinary_with_multiline_string
+    skip
+    assert_equal 0, Trinary.new("Invalid\n201\nString").to_decimal
+  end
 end


### PR DESCRIPTION
Solutions that check for decimals in "normalization" should be stricter
than simply checking for decimals.