### PR TITLE
Trinary: Test with multiline strings.

### DIFF
--- a/exercises/trinary/example.rb
+++ b/exercises/trinary/example.rb
@@ -3,7 +3,7 @@ class Trinary
 
   attr_reader :digits
   def initialize(decimal)
-    decimal = '0' unless decimal.match(/^[012]+$/)
+    decimal = '0' unless decimal.match(/\A[012]+\z/)
     @digits = decimal.reverse.chars.collect(&:to_i)
   end
 

--- a/exercises/trinary/trinary_test.rb
+++ b/exercises/trinary/trinary_test.rb
@@ -52,4 +52,9 @@ class TrinaryTest < Minitest::Test
     skip
     assert_equal 0, Trinary.new('0a1b2c').to_decimal
   end
+
+  def test_invalid_trinary_with_multiline_string
+    skip
+    assert_equal 0, Trinary.new("Invalid\n201\nString").to_decimal
+  end
 end


### PR DESCRIPTION
Many trinary solutions use a regex: /^[012]+$/ to check for trinary
validity which can be 'fooled' by strings which contain newlines.

This adds a test for that case.

(It also fixes the example solution which had that bug.)