### PR TITLE
Keys order doesn't matter in Hash equality

### DIFF
--- a/exercises/grade-school/example.rb
+++ b/exercises/grade-school/example.rb
@@ -1,5 +1,5 @@
 module BookKeeping
-  VERSION = 2
+  VERSION = 3
 end
 
 class School

--- a/exercises/grade-school/grade_school_test.rb
+++ b/exercises/grade-school/grade_school_test.rb
@@ -71,6 +71,7 @@ class SchoolTest < Minitest::Test
     end
     expected = everyone_sorted
     assert_equal expected, school.students_by_grade
+    assert_equal expected.keys, school.students_by_grade.keys
   end
 
   def everyone
@@ -104,6 +105,6 @@ class SchoolTest < Minitest::Test
 
   def test_bookkeeping
     skip
-    assert_equal 2, BookKeeping::VERSION
+    assert_equal 3, BookKeeping::VERSION
   end
 end


### PR DESCRIPTION
http://ruby-doc.org/core-2.3.1/Hash.html#method-i-3D-3D

So, I would add an assertion to ensure that Hashes are equal plus keys are in the same order.

Have a look please and let me know,

Thanks!