### PR TITLE
Change `students_by_grade` data structure. (+more) Closes #389

### DIFF
--- a/exercises/grade-school/example.rb
+++ b/exercises/grade-school/example.rb
@@ -1,22 +1,26 @@
-module BookKeeping
-  VERSION = 2
-end
-
 class School
   def initialize
-    @db = Hash.new { |db, grade| db[grade] = [] }
-  end
-
-  def add(student, grade)
-    @db[grade] << student
-  end
-
-  def grade(level)
-    @db[level].sort
+    @students = Hash.new { |hash, key| hash[key] = [] }
   end
 
   def students_by_grade
-    sorted = @db.map { |grade, students| [grade, students.sort] }.sort
-    Hash[sorted]
+    @students.keys.sort.map { |level| grade(level) }
   end
+
+  def add(student, level)
+    @students[level] << student
+    @students[level].sort!
+  end
+
+  def students(level)
+    @students[level]
+  end
+
+  def grade(level)
+    { grade: level, students: students(level) }
+  end
+end
+
+module BookKeeping
+  VERSION = 3
 end

--- a/exercises/grade-school/grade_school_test.rb
+++ b/exercises/grade-school/grade_school_test.rb
@@ -7,7 +7,7 @@ class SchoolTest < Minitest::Test
   def test_empty_grade
     school = School.new
     expected = []
-    assert_equal expected, school.grade(1)
+    assert_equal expected, school.students(1)
   end
 
   def test_add_student
@@ -15,7 +15,7 @@ class SchoolTest < Minitest::Test
     school = School.new
     assert school.add('Aimee', 2)
     expected = ['Aimee']
-    assert_equal expected, school.grade(2)
+    assert_equal expected, school.students(2)
   end
 
   def test_add_students_to_different_grades
@@ -23,8 +23,8 @@ class SchoolTest < Minitest::Test
     school = School.new
     school.add('Aimee', 3)
     school.add('Beemee', 7)
-    assert_equal ['Aimee'], school.grade(3)
-    assert_equal ['Beemee'], school.grade(7)
+    assert_equal ['Aimee'], school.students(3)
+    assert_equal ['Beemee'], school.students(7)
   end
 
   def test_grade_with_multiple_students
@@ -33,7 +33,7 @@ class SchoolTest < Minitest::Test
     grade    = 6
     students = %w(Aimee Beemee Ceemee)
     students.each { |student| school.add(student, grade) }
-    assert_equal students, school.grade(grade)
+    assert_equal students, school.students(grade)
   end
 
   def test_grade_with_multiple_students_sorts_correctly
@@ -43,13 +43,13 @@ class SchoolTest < Minitest::Test
     students = %w(Beemee Aimee Ceemee)
     students.each { |student| school.add(student, grade) }
     expected = students.sort
-    assert_equal expected, school.grade(grade)
+    assert_equal expected, school.students(grade)
   end
 
   def test_empty_students_by_grade
     skip
     school = School.new
-    expected = {}
+    expected = []
     assert_equal expected, school.students_by_grade
   end
 
@@ -59,30 +59,34 @@ class SchoolTest < Minitest::Test
     grade    = 6
     students = %w(Beemee Aimee Ceemee)
     students.each { |student| school.add(student, grade) }
-    expected = { grade => students.sort }
+    expected = [{ grade: grade, students: students.sort }]
     assert_equal expected, school.students_by_grade
   end
 
   def test_students_by_grade_sorted
     skip
     school = School.new
-    everyone.each do |grade, students|
-      students.each { |student| school.add(student, grade) }
+    everyone.each do |grade|
+      grade[:students].each { |student| school.add(student, grade[:grade]) }
     end
     expected = everyone_sorted
     assert_equal expected, school.students_by_grade
   end
 
   def everyone
-    { 2 => %w(Beemee Aimee Ceemee),
-      1 => %w(Effmee Geemee),
-      3 => %w(Eeemee Deemee) }
+    [
+      { grade: 3, students: %w(Deemee Eeemee) },
+      { grade: 1, students: %w(Effmee Geemee) },
+      { grade: 2, students: %w(Aimee Beemee Ceemee) }
+    ]
   end
 
   def everyone_sorted
-    { 1 => %w(Effmee Geemee),
-      2 => %w(Aimee Beemee Ceemee),
-      3 => %w(Deemee Eeemee) }
+    [
+      { grade: 1, students: %w(Effmee Geemee) },
+      { grade: 2, students: %w(Aimee Beemee Ceemee) },
+      { grade: 3, students: %w(Deemee Eeemee) }
+    ]
   end
 
   # Problems in exercism evolve over time, as we find better ways to ask
@@ -104,6 +108,6 @@ class SchoolTest < Minitest::Test
 
   def test_bookkeeping
     skip
-    assert_equal 2, BookKeeping::VERSION
+    assert_equal 3, BookKeeping::VERSION
   end
 end


### PR DESCRIPTION
Change the data structure returned by `students_by_grade` in order to
adhere to the "sorted list" criteria specified in the readme.

Rename `grade` method to `students`.

Update version number.

In the example solution, rename `grade` parameter to `level` to try to
eliminate confusion due to multiple different usages of `grade`.