### PR TITLE
Corrected numbering for step 5

### DIFF
--- a/exercises/hello-world/GETTING_STARTED.md
+++ b/exercises/hello-world/GETTING_STARTED.md
@@ -122,7 +122,7 @@ and the test is expecting one outcome, but getting another.
 The test is expecting the `hello` method to return the string `"Hello, World!"`. The easiest way
 to make it pass, is to simply stick the string `"Hello, World!"` inside the method definition.
 
-## Step 6
+## Step 5
 
 Run the test again.
 


### PR DESCRIPTION
Simple typo in the GETTING_STARTED.md guide for the Hello World exercise. Steps were numbered 1, 2, 3, 4, 6. Now they are 1, 2, 3, 4, 5.