### PR TITLE
Re-generate binary tests with split assertions

### DIFF
--- a/exercises/binary/binary_test.rb
+++ b/exercises/binary/binary_test.rb
@@ -5,7 +5,7 @@ require 'minitest/autorun'
 require_relative 'binary'
 
 # Test data version:
-# dd43e66
+# 01092b0
 class BinaryTest < Minitest::Test
   def test_binary_0_is_decimal_0
     # skip
@@ -52,18 +52,34 @@ class BinaryTest < Minitest::Test
     assert_equal 31, Binary.new('000011111').to_decimal
   end
 
-  def test_numbers_other_than_one_and_zero_raise_an_error
+  def test_2_is_not_a_valid_binary_digit
     skip
-    %w(012 2).each do |input|
-      assert_raises(ArgumentError) { Binary.new(input) }
-    end
+    assert_raises(ArgumentError) { Binary.new('2') }
   end
 
-  def test_containing_letters_raises_an_error
+  def test_a_number_containing_a_non_binary_digit_is_invalid
     skip
-    %w(10nope nope10 10nope10 001\ nope).each do |input|
-      assert_raises(ArgumentError) { Binary.new(input) }
-    end
+    assert_raises(ArgumentError) { Binary.new('01201') }
+  end
+
+  def test_a_number_with_trailing_non_binary_characters_is_invalid
+    skip
+    assert_raises(ArgumentError) { Binary.new('10nope') }
+  end
+
+  def test_a_number_with_leading_non_binary_characters_is_invalid
+    skip
+    assert_raises(ArgumentError) { Binary.new('nope10') }
+  end
+
+  def test_a_number_with_internal_non_binary_characters_is_invalid
+    skip
+    assert_raises(ArgumentError) { Binary.new('10nope10') }
+  end
+
+  def test_a_number_and_a_word_whitespace_spearated_is_invalid
+    skip
+    assert_raises(ArgumentError) { Binary.new('001 nope') }
   end
 
   # Problems in exercism evolve over time, as we find better ways to ask

--- a/lib/binary_cases.rb
+++ b/lib/binary_cases.rb
@@ -4,8 +4,8 @@ class BinaryCase < OpenStruct
   end
 
   def assertion
-    return compound_assertion if multiple_assertions?
-    Assertion.new("'#{binary}'", expected).to_s
+    return error_assertion if raises_error?
+    equality_assertion
   end
 
   def skipped
@@ -14,47 +14,20 @@ class BinaryCase < OpenStruct
 
   private
 
-  def multiple_assertions?
-    binary.is_a?(Array)
+  def error_assertion
+    "assert_raises(ArgumentError) { #{work_load} }"
   end
 
-  def compound_assertion
-    inputs = binary.map { |e| e.gsub(' ', '\ ') }.join(' ')
-    %(%w(#{inputs}).each do |input|
-      #{Assertion.new('input', expected)}
-    end)
+  def equality_assertion
+    "assert_equal #{expected}, #{work_load}"
   end
 
-  class Assertion
-    def initialize(initialization_value, expected)
-      @initialization_value = initialization_value
-      @expected = expected
-    end
+  def work_load
+    "Binary.new('#{binary}')#{'.to_decimal' unless raises_error?}"
+  end
 
-    def to_s
-      return error_assertion if raises_error?
-      equality_assertion
-    end
-
-    private
-
-    attr_reader :initialization_value, :expected
-
-    def error_assertion
-      "assert_raises(ArgumentError) { #{work_load} }"
-    end
-
-    def equality_assertion
-      "assert_equal #{expected}, #{work_load}"
-    end
-
-    def work_load
-      "Binary.new(#{initialization_value})#{'.to_decimal' unless raises_error?}"
-    end
-
-    def raises_error?
-      expected.to_i == -1
-    end
+  def raises_error?
+    expected.nil?
   end
 end
 


### PR DESCRIPTION
Resolves #404 

With changes proposed at exercism/x-common#303 and based on test data proposed at exercism/x-common#305.

This PR includes two changes:
* Re-generate tests from exercism/x-common
* Remove compound assertion logic from BinaryCases since all tests with multiple assertions have been split into separate tests.

Thank you so much for your time and feedback!