### PR TITLE
Possible changes in scale-generator

### DIFF
--- a/exercises/scale-generator/example.rb
+++ b/exercises/scale-generator/example.rb
@@ -34,3 +34,7 @@ class Scale
     chromatic_scale[index..-1] + chromatic_scale[0..index - 1]
   end
 end
+
+module BookKeeping
+  VERSION = 1
+end

--- a/exercises/scale-generator/scale_generator_test.rb
+++ b/exercises/scale-generator/scale_generator_test.rb
@@ -146,4 +146,26 @@ class ScaleGeneratorTest < Minitest::Test
     actual = enigmatic.pitches
     assert_equal expected, actual
   end
+
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
+  # The version number refers to the version of the problem you solved,
+  # not your solution.
+  #
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
+  # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
+  def test_bookkeeping
+    skip
+    assert_equal 1, BookKeeping::VERSION
+  end
 end

--- a/exercises/scale-generator/scale_generator_test.rb
+++ b/exercises/scale-generator/scale_generator_test.rb
@@ -109,7 +109,7 @@ class ScaleGeneratorTest < Minitest::Test
 
   def test_harmonic_minor
     skip
-    harmonic_minor = Scale.new('d', 'harmonic_minor', 'MmMMmAm')
+    harmonic_minor = Scale.new('d', :harmonic_minor, 'MmMMmAm')
     expected = %w(D E F G A Bb Db)
     actual = harmonic_minor.pitches
     assert_equal expected, actual

--- a/exercises/scale-generator/scale_generator_test.rb
+++ b/exercises/scale-generator/scale_generator_test.rb
@@ -14,7 +14,7 @@ class ScaleGeneratorTest < Minitest::Test
   def test_chromatic_scale
     skip
     chromatic = Scale.new('C', :chromatic)
-    expected = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+    expected = %w(C C# D D# E F F# G G# A A# B)
     actual = chromatic.pitches
     assert_equal expected, actual
   end
@@ -46,7 +46,7 @@ class ScaleGeneratorTest < Minitest::Test
   def test_another_major_scale
     skip
     major = Scale.new('G', :major, 'MMmMMMm')
-    expected = ['G', 'A', 'B', 'C', 'D', 'E', 'F#']
+    expected = %w(G A B C D E F#)
     actual = major.pitches
     assert_equal expected, actual
   end
@@ -54,7 +54,7 @@ class ScaleGeneratorTest < Minitest::Test
   def test_minor_scale
     skip
     minor = Scale.new('f#', :minor, 'MmMMmMM')
-    expected = ['F#', 'G#', 'A', 'B', 'C#', 'D', 'E']
+    expected = %w(F# G# A B C# D E)
     actual = minor.pitches
     assert_equal expected, actual
   end
@@ -86,7 +86,7 @@ class ScaleGeneratorTest < Minitest::Test
   def test_lydian_mode
     skip
     lydian = Scale.new('a', :lydian, 'MMMmMMm')
-    expected = ['A', 'B', 'C#', 'D#', 'E', 'F#', 'G#']
+    expected = %w(A B C# D# E F# G#)
     actual = lydian.pitches
     assert_equal expected, actual
   end
@@ -118,7 +118,7 @@ class ScaleGeneratorTest < Minitest::Test
   def test_octatonic
     skip
     octatonic = Scale.new('C', :octatonic, 'MmMmMmMm')
-    expected = ['C', 'D', 'D#', 'F', 'F#', 'G#', 'A', 'B']
+    expected = %w(C D D# F F# G# A B)
     actual = octatonic.pitches
     assert_equal expected, actual
   end
@@ -134,7 +134,7 @@ class ScaleGeneratorTest < Minitest::Test
   def test_pentatonic
     skip
     pentatonic = Scale.new('A', :pentatonic, 'MMAMA')
-    expected = ['A', 'B', 'C#', 'E', 'F#']
+    expected = %w(A B C# E F#)
     actual = pentatonic.pitches
     assert_equal expected, actual
   end
@@ -142,7 +142,7 @@ class ScaleGeneratorTest < Minitest::Test
   def test_enigmatic
     skip
     enigmatic = Scale.new('G', :enigma, 'mAMMMmM')
-    expected = ['G', 'G#', 'B', 'C#', 'D#', 'F', 'F#']
+    expected = %w(G G# B C# D# F F#)
     actual = enigmatic.pitches
     assert_equal expected, actual
   end


### PR DESCRIPTION
Maybe there's a reason to write all flats with `%` and all sharps with `[]`. Otherwise, I think would be better to unify criteria. Idem about scale names.

Please have a look and let me know.

Thanks!.