### PR TITLE
Gigaseconds example code simplified

### DIFF
--- a/exercises/gigasecond/example.rb
+++ b/exercises/gigasecond/example.rb
@@ -5,7 +5,7 @@ end
 class Gigasecond
   SECONDS = 10**9
 
-  def self.from(time)
-    (time.to_time + SECONDS).to_time
+  def self.from(seconds)
+    seconds + SECONDS
   end
 end


### PR DESCRIPTION
The Gigasecond from method does not require that it be given a time
object, only that the object given responds to + and works with numbers.

The README supports this by avoiding any mention of specific "type" of
return, only mentioning "a moment".