### PR TITLE
Add word count generator

### DIFF
--- a/exercises/word-count/example.tt
+++ b/exercises/word-count/example.tt
@@ -7,9 +7,10 @@ require_relative 'word_count'
 # <%= sha1 %>
 class PhraseTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
-    skip<% end %><% if test_case.raises_error? %>
-    assert_raises(ArgumentError) { <%= test_case.do %> }<% else %>
-    assert_equal <%= test_case.expected %>, <%= test_case.do %><% end %>
+    skip<% end %>
+    phrase = <%= test_case.object_under_test %>
+    counts = <%= test_case.expected %>
+    assert_equal counts, phrase.word_count
   end
 <% end %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>

--- a/exercises/word-count/word_count_test.rb
+++ b/exercises/word-count/word_count_test.rb
@@ -35,9 +35,7 @@ class PhraseTest < Minitest::Test
 
   def test_handles_expanded_lists
     skip
-    phrase = Phrase.new("one,
-two,
-three")
+    phrase = Phrase.new("one,\ntwo,\nthree")
     counts = {"one"=>1, "two"=>1, "three"=>1}
     assert_equal counts, phrase.word_count
   end

--- a/exercises/word-count/word_count_test.rb
+++ b/exercises/word-count/word_count_test.rb
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'word_count'
 
 # Test data version:
-
+# 5b5e807
 class PhraseTest < Minitest::Test
   def test_count_one_word
     phrase = Phrase.new('word')
@@ -12,28 +12,17 @@ class PhraseTest < Minitest::Test
     assert_equal counts, phrase.word_count
   end
 
-  def test_count_one_of_each
+  def test_count_one_of_each_word
     skip
     phrase = Phrase.new('one of each')
     counts = { 'one' => 1, 'of' => 1, 'each' => 1 }
     assert_equal counts, phrase.word_count
   end
 
-  def test_count_multiple_occurrences
+  def test_multiple_occurrences_of_a_word
     skip
     phrase = Phrase.new('one fish two fish red fish blue fish')
     counts = { 'one' => 1, 'fish' => 4, 'two' => 1, 'red' => 1, 'blue' => 1 }
-    assert_equal counts, phrase.word_count
-  end
-
-  def test_count_everything_just_once
-    skip
-    phrase = Phrase.new('all the kings horses and all the kings men')
-    phrase.word_count # count it an extra time
-    counts = {
-      'all' => 2, 'the' => 2, 'kings' => 2,
-      'horses' => 1, 'and' => 1, 'men' => 1
-    }
     assert_equal counts, phrase.word_count
   end
 
@@ -41,23 +30,12 @@ class PhraseTest < Minitest::Test
     skip
     phrase = Phrase.new('car : carpet as java : javascript!!&@$%^&')
     counts = {
-      'car' => 1, 'carpet' => 1, 'as' => 1,
-      'java' => 1, 'javascript' => 1
+      'car' => 1,
+      'carpet' => 1,
+      'as' => 1,
+      'java' => 1,
+      'javascript' => 1
     }
-    assert_equal counts, phrase.word_count
-  end
-
-  def test_handles_cramped_lists
-    skip
-    phrase = Phrase.new('one,two,three')
-    counts = { 'one' => 1, 'two' => 1, 'three' => 1 }
-    assert_equal counts, phrase.word_count
-  end
-
-  def test_handles_expanded_lists
-    skip
-    phrase = Phrase.new("one,\ntwo,\nthree")
-    counts = { 'one' => 1, 'two' => 1, 'three' => 1 }
     assert_equal counts, phrase.word_count
   end
 
@@ -70,39 +48,28 @@ class PhraseTest < Minitest::Test
 
   def test_normalize_case
     skip
-    phrase = Phrase.new('go Go GO')
-    counts = { 'go' => 3 }
+    phrase = Phrase.new('go Go GO Stop stop')
+    counts = { 'go' => 3, 'stop' => 2 }
     assert_equal counts, phrase.word_count
   end
 
-  def test_with_apostrophes
-    skip
-    phrase = Phrase.new("First: don't laugh. Then: don't cry.")
-    counts = {
-      'first' => 1, "don't" => 2, 'laugh' => 1,
-      'then' => 1, 'cry' => 1
-    }
-    assert_equal counts, phrase.word_count
-  end
-
-  def test_with_quotations
-    skip
-    phrase = Phrase.new("Joe can't tell between 'large' and large.")
-    counts = {
-      'joe' => 1, "can't" => 1, 'tell' => 1,
-      'between' => 1, 'large' => 2, 'and' => 1
-    }
-    assert_equal counts, phrase.word_count
-  end
-
-  # Problems in exercism evolve over time,
-  # as we find better ways to ask questions.
+  # Problems in exercism evolve over time, as we find better ways to ask
+  # questions.
   # The version number refers to the version of the problem you solved,
   # not your solution.
   #
-  # Define a constant named VERSION inside of BookKeeping.
-  # If you're curious, read more about constants on RubyDoc:
+  # Define a constant named VERSION inside of the top level BookKeeping
+  # module, which may be placed near the end of your file.
+  #
+  # In your file, it will look like this:
+  #
+  # module BookKeeping
+  #   VERSION = 1 # Where the version number matches the one in the test.
+  # end
+  #
+  # If you are curious, read more about constants on RubyDoc:
   # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.html
+
   def test_bookkeeping
     skip
     assert_equal 1, BookKeeping::VERSION

--- a/exercises/word-count/word_count_test.rb
+++ b/exercises/word-count/word_count_test.rb
@@ -7,49 +7,73 @@ require_relative 'word_count'
 # 5b5e807
 class PhraseTest < Minitest::Test
   def test_count_one_word
-    phrase = Phrase.new('word')
-    counts = { 'word' => 1 }
+    phrase = Phrase.new("word")
+    counts = {"word"=>1}
     assert_equal counts, phrase.word_count
   end
 
   def test_count_one_of_each_word
     skip
-    phrase = Phrase.new('one of each')
-    counts = { 'one' => 1, 'of' => 1, 'each' => 1 }
+    phrase = Phrase.new("one of each")
+    counts = {"one"=>1, "of"=>1, "each"=>1}
     assert_equal counts, phrase.word_count
   end
 
   def test_multiple_occurrences_of_a_word
     skip
-    phrase = Phrase.new('one fish two fish red fish blue fish')
-    counts = { 'one' => 1, 'fish' => 4, 'two' => 1, 'red' => 1, 'blue' => 1 }
+    phrase = Phrase.new("one fish two fish red fish blue fish")
+    counts = {"one"=>1, "fish"=>4, "two"=>1, "red"=>1, "blue"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_handles_cramped_lists
+    skip
+    phrase = Phrase.new("one,two,three")
+    counts = {"one"=>1, "two"=>1, "three"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_handles_expanded_lists
+    skip
+    phrase = Phrase.new("one,
+two,
+three")
+    counts = {"one"=>1, "two"=>1, "three"=>1}
     assert_equal counts, phrase.word_count
   end
 
   def test_ignore_punctuation
     skip
-    phrase = Phrase.new('car : carpet as java : javascript!!&@$%^&')
-    counts = {
-      'car' => 1,
-      'carpet' => 1,
-      'as' => 1,
-      'java' => 1,
-      'javascript' => 1
-    }
+    phrase = Phrase.new("car: carpet as java: javascript!!&@$%^&")
+    counts = {"car"=>1, "carpet"=>1, "as"=>1, "java"=>1, "javascript"=>1}
     assert_equal counts, phrase.word_count
   end
 
   def test_include_numbers
     skip
-    phrase = Phrase.new('testing, 1, 2 testing')
-    counts = { 'testing' => 2, '1' => 1, '2' => 1 }
+    phrase = Phrase.new("testing, 1, 2 testing")
+    counts = {"testing"=>2, "1"=>1, "2"=>1}
     assert_equal counts, phrase.word_count
   end
 
   def test_normalize_case
     skip
-    phrase = Phrase.new('go Go GO Stop stop')
-    counts = { 'go' => 3, 'stop' => 2 }
+    phrase = Phrase.new("go Go GO Stop stop")
+    counts = {"go"=>3, "stop"=>2}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_with_apostrophes
+    skip
+    phrase = Phrase.new("First: don't laugh. Then: don't cry.")
+    counts = {"first"=>1, "don't"=>2, "laugh"=>1, "then"=>1, "cry"=>1}
+    assert_equal counts, phrase.word_count
+  end
+
+  def test_with_quotations
+    skip
+    phrase = Phrase.new("Joe can't tell between 'large' and large.")
+    counts = {"joe"=>1, "can't"=>1, "tell"=>1, "between"=>1, "large"=>2, "and"=>1}
     assert_equal counts, phrase.word_count
   end
 
@@ -75,3 +99,4 @@ class PhraseTest < Minitest::Test
     assert_equal 1, BookKeeping::VERSION
   end
 end
+

--- a/lib/word_count_cases.rb
+++ b/lib/word_count_cases.rb
@@ -4,7 +4,7 @@ class WordCountCase < OpenStruct
   end
 
   def object_under_test
-    "Phrase.new('#{input}')"
+    %Q(Phrase.new("#{input}"))
   end
 
   def skipped?

--- a/lib/word_count_cases.rb
+++ b/lib/word_count_cases.rb
@@ -4,7 +4,7 @@ class WordCountCase < OpenStruct
   end
 
   def object_under_test
-    %Q(Phrase.new(#{input.to_json}))
+    %Q(Phrase.new(#{input.inspect}))
   end
 
   def skipped?

--- a/lib/word_count_cases.rb
+++ b/lib/word_count_cases.rb
@@ -1,0 +1,19 @@
+class WordCountCase < OpenStruct
+  def name
+    'test_%s' % description.tr(' ', '_')
+  end
+
+  def object_under_test
+    "Phrase.new('#{input}')"
+  end
+
+  def skipped?
+    index.nonzero?
+  end
+end
+
+WordCountCases = proc do |data|
+  JSON.parse(data)['cases'].map.with_index do |row, i|
+    WordCountCase.new(row.merge('index' => i))
+  end
+end

--- a/lib/word_count_cases.rb
+++ b/lib/word_count_cases.rb
@@ -4,7 +4,7 @@ class WordCountCase < OpenStruct
   end
 
   def object_under_test
-    %Q(Phrase.new("#{input}"))
+    %Q(Phrase.new(#{input.to_json}))
   end
 
   def skipped?


### PR DESCRIPTION
In the list of exercises that need a generator #396 , I saw word-count. Once I started working on it, I found the template `exercises/word-count/example.tt ` but I couldn't find any generator associated to it, so I decided to modify the current template and create the generator that you can see in this PR.
 
The `canonical-data.json` file from x-common has less examples that the current version of `word_count_test.rb` Should I add these examples to x-common?