### PR TITLE
Common generate script

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ tree -L 1 ~/code/exercism
 1. `xruby/$PROBLEM/example.tt` - the Erb template for the test file, `$PROBLEM_test.rb`.
 1. `x-common/$PROBLEM.json` - the shared inputs and outputs for the problem.
 1. `lib/$PROBLEM.rb` - the logic for turning the data into tests.
-1. `xruby/bin/generate-$PROBLEM` - the command to actually generate the test suite.
+1. `xruby/bin/generate $PROBLEM` - the command to actually generate the test suite.
 1. `.version` - used to keep track of the version of the test files as the data changes.
 
 Additionally, there is some common generator logic in `lib/generator.rb`.
@@ -98,7 +98,7 @@ For example, take a look at the `hamming.json` file in the x-common repository, 
 as the following files in the xruby repository:
 
 1. `hamming/example.tt`
-1. `bin/generate-hamming`
+1. `bin/generate hamming`
 1. `lib/hamming.rb`
 1. `lib/generator.rb`
 

--- a/bin/generate
+++ b/bin/generate
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+exercise = ARGV[0]
+cases = "#{exercise.tr('-','_')}_cases"
+
+require_relative '../lib/helper'
+require 'generator'
+begin
+  require "#{cases}"
+rescue LoadError
+  puts "A generator does not currently exist for #{exercise}!"
+  exit(1)
+end
+
+klass = Object.const_get(cases.split('_').map(&:capitalize).join)
+Generator.new(exercise, klass).generate

--- a/bin/generate-acronym
+++ b/bin/generate-acronym
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'acronym_cases'
-
-Generator.new('acronym', AcronymCases).generate

--- a/bin/generate-alphametics
+++ b/bin/generate-alphametics
@@ -1,8 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'alphametics_cases'
-
-Generator.new('alphametics', AlphameticsCases).generate
-

--- a/bin/generate-binary
+++ b/bin/generate-binary
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'binary_cases'
-
-Generator.new('binary', BinaryCases).generate

--- a/bin/generate-bracket-push
+++ b/bin/generate-bracket-push
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'bracket_push_cases'
-
-Generator.new('bracket-push', BracketsCases).generate

--- a/bin/generate-clock
+++ b/bin/generate-clock
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'clock_cases'
-
-Generator.new('clock', ClockCases).generate

--- a/bin/generate-connect
+++ b/bin/generate-connect
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'connect_cases'
-
-Generator.new('connect', ConnectCases).generate

--- a/bin/generate-custom-set
+++ b/bin/generate-custom-set
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'custom_set_cases'
-
-Generator.new('custom-set', CustomSetCases).generate

--- a/bin/generate-difference-of-squares
+++ b/bin/generate-difference-of-squares
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'difference_of_squares_cases'
-
-Generator.new('difference-of-squares', DifferenceOfSquaresCases).generate

--- a/bin/generate-gigasecond
+++ b/bin/generate-gigasecond
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'gigasecond_cases'
-
-Generator.new('gigasecond', GigasecondCases).generate

--- a/bin/generate-hamming
+++ b/bin/generate-hamming
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'hamming_cases'
-
-Generator.new('hamming', HammingCases).generate

--- a/bin/generate-hello-world
+++ b/bin/generate-hello-world
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'hello_world_cases'
-
-Generator.new('hello-world', HelloWorldCases).generate

--- a/bin/generate-largest-series-product
+++ b/bin/generate-largest-series-product
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'largest_series_product_cases'
-
-Generator.new('largest-series-product', LargestSeriesProductCases).generate

--- a/bin/generate-leap
+++ b/bin/generate-leap
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'leap_cases'
-
-Generator.new('leap', LeapCases).generate

--- a/bin/generate-nth-prime
+++ b/bin/generate-nth-prime
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'nth_prime_cases'
-
-Generator.new('nth-prime', NthPrimeCases).generate

--- a/bin/generate-pangram
+++ b/bin/generate-pangram
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'pangram_cases'
-
-Generator.new('pangram', PangramCases).generate

--- a/bin/generate-raindrops
+++ b/bin/generate-raindrops
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'raindrop_cases'
-
-Generator.new('raindrops', RaindropCases).generate

--- a/bin/generate-rna-transcription
+++ b/bin/generate-rna-transcription
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'rna_transcription_cases'
-
-Generator.new('rna-transcription', RnaTranscriptionCases).generate

--- a/bin/generate-roman-numerals
+++ b/bin/generate-roman-numerals
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'roman_numerals_cases'
-
-Generator.new('roman-numerals', RomanNumeralsCases).generate

--- a/bin/generate-run-length-encoding
+++ b/bin/generate-run-length-encoding
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'run_length_encoding_cases'
-
-Generator.new('run-length-encoding', RunLengthEncodingCases).generate

--- a/bin/generate-two-bucket
+++ b/bin/generate-two-bucket
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require_relative '../lib/helper'
-require 'generator'
-require 'two_bucket_cases'
-
-Generator.new('two-bucket', TwoBucketCases).generate

--- a/lib/bracket_push_cases.rb
+++ b/lib/bracket_push_cases.rb
@@ -1,4 +1,4 @@
-class BracketsCase < OpenStruct
+class BracketPushCase < OpenStruct
   def name
     'test_%s' % description.gsub(/[ -]/, '_')
   end
@@ -34,8 +34,8 @@ class BracketsCase < OpenStruct
   end
 end
 
-BracketsCases = proc do |data|
+BracketPushCases = proc do |data|
   JSON.parse(data)['cases'].map.with_index do |row, i|
-    BracketsCase.new(row.merge('index' => i))
+    BracketPushCase.new(row.merge('index' => i))
   end
 end

--- a/lib/raindrops_cases.rb
+++ b/lib/raindrops_cases.rb
@@ -12,7 +12,7 @@ class RaindropsCase < OpenStruct
   end
 end
 
-RaindropCases = proc do |data|
+RaindropsCases = proc do |data|
   JSON.parse(data)['cases'].map.with_index do |row, i|
     RaindropsCase.new(row.merge('index' => i))
   end


### PR DESCRIPTION
While creating a generator for acronym and noticed how each exercise had it own generate script. This leads to a lot of code duplication since each script is almost identical. 

This PR would allow for a single generate script that takes an exercise name as the argument, and regenerates the exercise.  If the exercise is not found and error message will display.  I tested it out on all the exercises and I had to modify two generators to ensure consistent naming.

Example usage:
`bin/generate raindrops`

Let me know if this is something that would be helpful!