### PR TITLE
[acronym] Remove rubocop:disable comment.

### DIFF
--- a/exercises/acronym/acronym_test.rb
+++ b/exercises/acronym/acronym_test.rb
@@ -5,7 +5,6 @@ require_relative 'acronym'
 
 # Test data version:
 # 5b5e807
-# rubocop:disable Metrics/LineLength
 class AcronymTest < Minitest::Test
   def test_basic
     assert_equal 'PNG', Acronym.abbreviate('Portable Network Graphics')


### PR DESCRIPTION
Remove rubocop:disable comment from `acronym_test.rb`
Addresses issue "Remove rubocop magic comments from user facing files #385"

(This PR is a simple example for any beginners working on #385)