### PR TITLE
bin/generate usage instructions.

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -1,10 +1,29 @@
 #!/usr/bin/env ruby
 
-exercise = ARGV[0]
-cases = "#{exercise.tr('-','_')}_cases"
-
 require_relative '../lib/helper'
 require 'generator'
+
+def available_generators
+  cases = File.join( __dir__, '../lib/*_cases.rb')
+  Dir[cases].map {|filename| /([^\/]*)_cases\.rb$/.match(filename).captures}
+end
+
+def usage
+  "Usage: #{$PROGRAM_NAME} exercise_generator\n\n" +
+  "Available exercise generators:\n" +
+  available_generators.sort.join(' ')
+end
+
+exercise = ARGV[0]
+
+unless exercise
+  STDERR.puts "Exercise name required!\n"
+  puts usage
+  exit
+end
+
+cases = "#{exercise.tr('-','_')}_cases"
+
 begin
   require "#{cases}"
 rescue LoadError
@@ -14,3 +33,4 @@ end
 
 klass = Object.const_get(cases.split('_').map(&:capitalize).join)
 Generator.new(exercise, klass).generate
+


### PR DESCRIPTION
Give usage instructions when bin/generate is called with no arguments.
The instructions also provide a list of the available generators.

Edit: Here's what it looks like:

``` shell
$ bin/generate 
Exercise name required!
Usage: bin/generate exercise_generator

Available exercise generators:
acronym alphametics binary bracket_push clock connect custom_set difference_of_squares gigase
cond hamming hello_world largest_series_product leap nth_prime pangram raindrops rna_transcri
ption roman_numerals run_length_encoding sieve two_bucket
```
