### PR TITLE
Bin files independent of pwd  (Fixes #291)

### DIFF
--- a/bin/enable-executable
+++ b/bin/enable-executable
@@ -2,14 +2,18 @@
 
 require 'fileutils'
 
-puts 'Ensuring test files are executable...'
+puts 'Ensuring test files are executable.'
 
-(Dir.glob('**/*test.rb') + Dir.glob('bin/*')).each do |f|
-  if File.executable?(f)
+# Assume that this file lives in #{base}/bin
+base = File.join(__dir__,'..')
+files = Dir.glob("#{base}/**/*test.rb") + Dir.glob("#{base}/bin/*")
+
+files.each do |file|
+  if File.executable?(file)
     print '.'
   else
-    print "\nAdding exec bit to #{f}"
-    FileUtils.chmod('u+x', f)
+    print "\nAdding exec bit to #{file}"
+    FileUtils.chmod('u+x', file)
   end
 end
 puts

--- a/bin/executable-tests-check
+++ b/bin/executable-tests-check
@@ -1,10 +1,14 @@
 #!/usr/bin/env ruby
 require 'minitest/autorun'
 
-(Dir.glob('**/*test.rb') + Dir.glob('bin/*')).each do |f|
-  describe f do
+# Assume that this file lives in #{base}/bin
+base = File.join(__dir__,'..')
+files = Dir.glob("#{base}/**/*test.rb") + Dir.glob("#{base}/bin/*")
+
+files.each do |file|
+  describe file do
     it 'should have the execution bit set' do
-      assert File.executable?(f), "Execution bit not set for #{f}"
+      assert File.executable?(file), "Execution bit not set for #{file}"
     end
   end
 end


### PR DESCRIPTION
Use path relative to the executable Ruby file in the xruby 'bin' directory rather than the current working directory which was the default behaviour.

This will enable the commands to be run from any working directory and still be able to access the files they need to check/update.

fixes #291

