### PR TITLE
Remove rubocop:disable comments from exercises/

### DIFF
--- a/exercises/allergies/allergies_test.rb
+++ b/exercises/allergies/allergies_test.rb
@@ -59,7 +59,6 @@ class AllergiesTest < Minitest::Test
   def test_allergic_to_everything
     skip
     allergies = Allergies.new(255)
-    # rubocop:disable Metrics/LineLength
     expected = %w(eggs peanuts shellfish strawberries tomatoes chocolate pollen cats)
     assert_equal expected, allergies.list
   end

--- a/exercises/atbash-cipher/atbash_cipher_test.rb
+++ b/exercises/atbash-cipher/atbash_cipher_test.rb
@@ -3,7 +3,6 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'atbash_cipher'
 
-# rubocop:disable Style/MethodName
 class AtbashTest < Minitest::Test
   def test_encode_no
     assert_equal 'ml', Atbash.encode('no')

--- a/exercises/beer-song/beer_song_test.rb
+++ b/exercises/beer-song/beer_song_test.rb
@@ -3,7 +3,6 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'beer_song'
 
-# rubocop:disable Metrics/LineLength
 class BeerSongTest < Minitest::Test
   def test_the_first_verse
     expected = "99 bottles of beer on the wall, 99 bottles of beer.\n" \
@@ -62,7 +61,7 @@ class BeerSongTest < Minitest::Test
     assert_equal expected, BeerSong.new.verses(2, 0)
   end
 
-  def test_the_whole_song # rubocop:disable Metrics/MethodLength
+  def test_the_whole_song
     skip
     expected = <<-SONG
 99 bottles of beer on the wall, 99 bottles of beer.

--- a/exercises/binary-search-tree/binary_search_tree_test.rb
+++ b/exercises/binary-search-tree/binary_search_tree_test.rb
@@ -32,7 +32,7 @@ class BstTest < Minitest::Test
     assert_equal 5, four.right.data
   end
 
-  def test_complex_tree # rubocop:disable Metrics/MethodLength
+  def test_complex_tree
     skip
     four = Bst.new 4
     four.insert 2

--- a/exercises/binary/example.rb
+++ b/exercises/binary/example.rb
@@ -19,7 +19,6 @@ class Binary
 
   private
 
-  # rubocop:disable Style/WordArray
   def valid?(s)
     s.chars.all? { |char| ['0', '1'].include?(char) }
   end

--- a/exercises/circular-buffer/circular_buffer_test.rb
+++ b/exercises/circular-buffer/circular_buffer_test.rb
@@ -89,7 +89,6 @@ class CircularBufferTest < Minitest::Test
     assert_raises(CircularBuffer::BufferEmptyException) { buffer.read }
   end
 
-  # rubocop:disable Metrics/MethodLength
   def test_alternate_read_and_write_into_buffer_overflow
     skip
     buffer = CircularBuffer.new(5)
@@ -108,5 +107,4 @@ class CircularBufferTest < Minitest::Test
     assert_equal 'B', buffer.read
     assert_raises(CircularBuffer::BufferEmptyException) { buffer.read }
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/exercises/clock/example.rb
+++ b/exercises/clock/example.rb
@@ -12,7 +12,6 @@ class Clock
     @internal = hours * 60 + minutes
   end
 
-  # rubocop:disable Style/OpMethod
   def +(hours=0, minutes)
     @internal += hours * 60 + minutes
     self
@@ -21,7 +20,6 @@ class Clock
   def -(*args)
     self.+(*args.map(&:-@))
   end
-  # rubocop:enable Style/OpMethod
 
   def ==(other)
     to_s == other.to_s

--- a/exercises/connect/connect_test.rb
+++ b/exercises/connect/connect_test.rb
@@ -95,7 +95,6 @@ class ConnectTest < Minitest::Test
     assert_equal 'X', game.winner, 'X wins using a convoluted path'
   end
 
-  # rubocop:disable MethodLength
   def test_x_wins_using_a_spiral_path
     skip
     board = [

--- a/exercises/custom-set/custom_set_test.rb
+++ b/exercises/custom-set/custom_set_test.rb
@@ -204,7 +204,6 @@ class CustomSetTest < Minitest::Test
     assert_equal expected, set2.intersection(set1)
   end
 
-  # rubocop:disable Metrics/LineLength
   def test_intersection_of_two_sets_with_shared_elements_is_a_set_of_the_shared_elements
     skip
     set1 = CustomSet.new [1, 2, 3, 4]

--- a/exercises/diamond/diamond_test.rb
+++ b/exercises/diamond/diamond_test.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/MethodLength
 # !/usr/bin/env ruby
 gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'

--- a/exercises/etl/etl_test.rb
+++ b/exercises/etl/etl_test.rb
@@ -32,7 +32,7 @@ class TransformTest < Minitest::Test
     assert_equal expected, ETL.transform(old)
   end
 
-  def test_full_dataset # rubocop:disable Metrics/MethodLength
+  def test_full_dataset
     skip
     old = {
       1 => %w(A E I O U L N R S T),

--- a/exercises/house/house_test.rb
+++ b/exercises/house/house_test.rb
@@ -3,7 +3,6 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'house'
 
-# rubocop:disable Metrics/MethodLength
 class HouseTest < Minitest::Test
   def test_rhyme
     expected = <<-RHYME

--- a/exercises/largest-series-product/example.tt
+++ b/exercises/largest-series-product/example.tt
@@ -5,9 +5,6 @@ require_relative 'largest_series_product'
 
 # Test data version:
 # <%= sha1 %>
-# Rubocop directives
-# rubocop:disable Style/NumericLiterals
-# rubocop:disable Metrics/LineLength
 #
 class Seriestest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>

--- a/exercises/largest-series-product/largest_series_product_test.rb
+++ b/exercises/largest-series-product/largest_series_product_test.rb
@@ -6,10 +6,6 @@ require_relative 'largest_series_product'
 # Test data version:
 # deb225e Implement canonical dataset for scrabble-score problem (#255)
 
-# Rubocop directives
-# rubocop:disable Style/NumericLiterals
-# rubocop:disable Metrics/LineLength
-#
 class Seriestest < Minitest::Test
   def test_can_find_the_largest_product_of_2_with_numbers_in_order
     assert_equal 72, Series.new('0123456789').largest_product(2)

--- a/exercises/linked-list/linked_list_test.rb
+++ b/exercises/linked-list/linked_list_test.rb
@@ -39,7 +39,7 @@ class DequeTest < Minitest::Test
     assert_equal 20, deque.pop
   end
 
-  def test_example # rubocop:disable Metrics/MethodLength
+  def test_example
     skip
     deque = Deque.new
     deque.push(10)

--- a/exercises/meetup/meetup_test.rb
+++ b/exercises/meetup/meetup_test.rb
@@ -8,7 +8,6 @@ require_relative 'meetup'
 # and a method day(weekday, schedule)
 # where weekday is one of :monday, :tuesday, etc
 # and schedule is :first, :second, :third, :fourth, :last or :teenth.
-# rubocop:disable Style/AlignParameters
 class MeetupTest < Minitest::Test
   def test_monteenth_of_may_2013
     assert_equal Date.new(2013, 5, 13),

--- a/exercises/nth-prime/example.tt
+++ b/exercises/nth-prime/example.tt
@@ -5,8 +5,6 @@ require_relative 'nth_prime'
 
 # Test data version:
 # <%= sha1 %>
-# Rubocop directives
-# rubocop:disable Style/NumericLiterals
 #
 class NthPrimeTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>

--- a/exercises/nth-prime/nth_prime_test.rb
+++ b/exercises/nth-prime/nth_prime_test.rb
@@ -5,8 +5,6 @@ require_relative 'nth_prime'
 
 # Test data version:
 # bb79e10
-# Rubocop directives
-# rubocop:disable Style/NumericLiterals
 #
 class NthPrimeTest < Minitest::Test
   def test_first_prime

--- a/exercises/ocr-numbers/ocr_numbers_test.rb
+++ b/exercises/ocr-numbers/ocr_numbers_test.rb
@@ -4,7 +4,6 @@ require 'minitest/autorun'
 require_relative 'ocr_numbers'
 
 class OCRTest < Minitest::Test
-  # rubocop:disable  Style/TrailingWhitespace
   def test_recognize_zero
     text = <<-NUMBER.chomp
  _ 
@@ -169,7 +168,7 @@ class OCRTest < Minitest::Test
     assert_equal '1234567890', OCR.new(text).convert
   end
 
-  def test_identify_123_456_789 # rubocop:disable Metrics/MethodLength
+  def test_identify_123_456_789
     skip
     text = <<-NUMBER.chomp
     _  _ 

--- a/exercises/protein-translation/protein_translation_test.rb
+++ b/exercises/protein-translation/protein_translation_test.rb
@@ -3,7 +3,6 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'protein_translation'
 
-# rubocop:disable Style/MethodName
 class TranslationTest < Minitest::Test
   def test_AUG_translates_to_methionine
     assert_equal 'Methionine', Translation.of_codon('AUG')

--- a/exercises/proverb/proverb_test.rb
+++ b/exercises/proverb/proverb_test.rb
@@ -38,7 +38,7 @@ class ProverbTest < Minitest::Test
     assert_equal expected, proverb.to_s
   end
 
-  def test_the_whole_proverb # rubocop:disable Metrics/MethodLength
+  def test_the_whole_proverb
     skip
     chain = %w(nail shoe horse rider message battle kingdom)
     proverb = Proverb.new(*chain)
@@ -52,7 +52,6 @@ class ProverbTest < Minitest::Test
     assert_equal expected, proverb.to_s
   end
 
-  # rubocop:disable Metrics/MethodLength
   def test_an_optional_qualifier_in_the_final_consequence
     skip
     chain = %w(nail shoe horse rider message battle kingdom)
@@ -66,7 +65,6 @@ class ProverbTest < Minitest::Test
       'And all for the want of a horseshoe nail.'
     assert_equal expected, proverb.to_s
   end
-  # rubocop:enable Metrics/MethodLength
 
   def test_proverb_is_same_each_time
     skip

--- a/exercises/queen-attack/queen_attack_test.rb
+++ b/exercises/queen-attack/queen_attack_test.rb
@@ -34,7 +34,7 @@ class QueensTest < Minitest::Test
     end
   end
 
-  def test_string_representation # rubocop:disable Metrics/MethodLength
+  def test_string_representation
     skip
     queens = Queens.new(white: [2, 4], black: [6, 6])
     board = <<-BOARD.chomp
@@ -50,7 +50,7 @@ _ _ _ _ _ _ _ _
     assert_equal board, queens.to_s
   end
 
-  def test_another_string_representation # rubocop:disable Metrics/MethodLength
+  def test_another_string_representation
     skip
     queens = Queens.new(white: [7, 1], black: [0, 0])
     board = <<-BOARD.chomp
@@ -66,7 +66,6 @@ _ W _ _ _ _ _ _
     assert_equal board, queens.to_s
   end
 
-  # rubocop:disable Metrics/MethodLength
   def test_yet_another_string_representation
     skip
     queens = Queens.new(white: [4, 3], black: [3, 4])
@@ -88,7 +87,6 @@ _ _ _ _ _ _ _ _
     queens = Queens.new(white: [2, 3], black: [4, 7])
     assert !queens.attack?
   end
-  # rubocop:enable Metrics/MethodLength
 
   def test_can_attack_on_same_row
     skip

--- a/exercises/robot-simulator/robot_simulator_test.rb
+++ b/exercises/robot-simulator/robot_simulator_test.rb
@@ -160,7 +160,7 @@ class RobotSimulatorTest < Minitest::Test
     assert_equal :west, robot.bearing
   end
 
-  def test_instruct_many_robots # rubocop:disable Metrics/MethodLength
+  def test_instruct_many_robots
     skip
     robot1 = Robot.new
     robot2 = Robot.new

--- a/exercises/strain/strain_test.rb
+++ b/exercises/strain/strain_test.rb
@@ -30,7 +30,7 @@ class ArrayTest < Minitest::Test
     assert_equal %w(zebra zombies zelot), result
   end
 
-  def test_keep_arrays # rubocop:disable Metrics/MethodLength
+  def test_keep_arrays
     skip
     rows = [
       [1, 2, 3],
@@ -72,7 +72,7 @@ class ArrayTest < Minitest::Test
     assert_equal %w(apple banana cherimoya), result
   end
 
-  def test_discard_arrays # rubocop:disable Metrics/MethodLength
+  def test_discard_arrays
     skip
     rows = [
       [1, 2, 3],


### PR DESCRIPTION
Addresses issue "Remove rubocop magic comments from user facing files #385" for the rest of the files within `exercises/`

Rubocop still shows no errors with these inline comments removed.