### PR TITLE
[isogram] Eliminate trailing whitespace in test file.

### DIFF
--- a/exercises/isogram/isogram_test.rb
+++ b/exercises/isogram/isogram_test.rb
@@ -4,10 +4,10 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'isogram'
 
-# Common test data version: 3dfde31
+# Common test data version: c1cb73f
 class IsogramTest < Minitest::Test
   def test_duplicates
-    
+    # skip
     string = 'duplicates'
     assert Isogram.is_isogram?(string)
   end

--- a/lib/isogram_cases.rb
+++ b/lib/isogram_cases.rb
@@ -13,7 +13,7 @@ class IsogramCase < OpenStruct
   end
 
   def skip
-    'skip' unless index.zero?
+    index.zero? ? '# skip' : 'skip'
   end
 end
 


### PR DESCRIPTION
When the first test case is generated it leaves out the 'skip' But the
line still contains the whitespace present in the template file.

Add commented out skip to avoid having trailing whitespace.

I'm not sure this is an improvement, but it does provide the solver with
a hint about what they're supposed to do with the skips to make the
tests run.
