### PR TITLE
lib/generator.rb: Ignore blank template lines.

### DIFF
--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -64,7 +64,8 @@ class Generator
 
   def generate_test_file
     File.open(path_to("#{name.gsub(/[ -]/, '_')}_test.rb"), 'w') do |f|
-      f.write ERB.new(File.read(path_to('example.tt'))).result binding
+      template = File.read(path_to('example.tt'))
+      f.write ERB.new(template, nil, '<>').result binding
     end
   end
 


### PR DESCRIPTION
If you have a template that contains a value that might be nil or an empty string such as:
```
<%= test_case.comment %>
```
You often do not want a blank line appear in the output if there is no comment.

This patch changes the ERB setttings so that these blank lines are not included in the output. 

This may cause minor issues where this behaviour has been relied on such as templates that expect a Ruby syntax related 'end' to insert a blank line.
```
<% end %>
```
But these are easily fixed by inserting a new blank line into the template.

Technical details:

It does this by setting the ERB *trim_mode* to '<>'
'<>' omits newline for lines starting with <% and ending in %>

See also: http://ruby-doc.org/stdlib-2.1.1/libdoc/erb/rdoc/ERB.html#method-c-new