### PR TITLE
Start unit testing lib/generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 gem 'minitest'
 gem 'rubocop', '0.36.0'
+gem 'simplecov'
+gem 'rake'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require 'rake'
+require 'rake/testtask'
+
+Rake::TestTask.new do |task|
+  task.pattern = 'test/*_test.rb'
+end

--- a/bin/executable-tests-check
+++ b/bin/executable-tests-check
@@ -3,7 +3,7 @@ require 'minitest/autorun'
 
 # Assume that this file lives in #{base}/bin
 base = File.join(__dir__,'..')
-files = Dir.glob("#{base}/**/*test.rb") + Dir.glob("#{base}/bin/*")
+files = Dir.glob("#{base}/exercises/**/*test.rb") + Dir.glob("#{base}/bin/*")
 
 files.each do |file|
   describe file do

--- a/config.json
+++ b/config.json
@@ -517,7 +517,8 @@
   "ignored": [
     "docs",
     "img",
-    "lib"
+    "lib",
+    "test"
   ],
   "foregone": [
 

--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -8,13 +8,18 @@ class Generator
   METADATA_REPOSITORY = 'x-common'.freeze
 
   attr_reader :name, :cases
-  def initialize(name, cases)
+  def initialize(name, cases, metadata_repository_path=nil)
     @name = name
     @cases = cases
+    @metadata_repository_path = metadata_repository_path || default_metadata_path
+  end
+
+  def default_metadata_path
+    File.join( '..', METADATA_REPOSITORY)
   end
 
   def metadata_dir
-    File.expand_path(File.join('..', '..', '..', METADATA_REPOSITORY, 'exercises', name), __FILE__)
+    File.join(@metadata_repository_path, 'exercises', name)
   end
 
   def exercise_dir

--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -23,7 +23,7 @@ class Generator
   end
 
   def exercise_dir
-    File.expand_path(File.join('..', '..', 'exercises', name), __FILE__)
+    File.join('exercises', name)
   end
 
   def exercise_meta_dir

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -2,22 +2,20 @@ require_relative 'test_helper'
 
 class GeneratorTest < Minitest::Test
   def test_default_metadata_path
-    subject = Generator.new('aname', 'some cases')
+    subject = Generator.new('aname', nil)
     # This is relative to the xruby root
     assert_equal '../x-common/exercises/aname', subject.metadata_dir
   end
 
   def test_initalize_with_fixture_path
     fixture_path = 'xruby/test/fixtures'
-    subject = Generator.new('aname', 'some cases', fixture_path)
+    subject = Generator.new('aname', nil, fixture_path)
     assert_equal 'xruby/test/fixtures/exercises/aname', subject.metadata_dir
   end
 
   def test_exercise_dir
-    subject = Generator.new('aname', 'some cases')
+    subject = Generator.new('aname', nil)
     # This is relative to the xruby root
     assert_equal 'exercises/aname', subject.exercise_dir
   end
-
 end
-

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -1,0 +1,9 @@
+require_relative 'test_helper'
+
+class GeneratorTest < Minitest::Test
+  def test_initalize
+    subject = Generator.new('a name', 'some cases')
+    assert_instance_of Generator, subject
+  end
+end
+

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -13,5 +13,11 @@ class GeneratorTest < Minitest::Test
     assert_equal 'xruby/test/fixtures/exercises/aname', subject.metadata_dir
   end
 
+  def test_exercise_dir
+    subject = Generator.new('aname', 'some cases')
+    # This is relative to the xruby root
+    assert_equal 'exercises/aname', subject.exercise_dir
+  end
+
 end
 

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -1,9 +1,17 @@
 require_relative 'test_helper'
 
 class GeneratorTest < Minitest::Test
-  def test_initalize
-    subject = Generator.new('a name', 'some cases')
-    assert_instance_of Generator, subject
+  def test_default_metadata_path
+    subject = Generator.new('aname', 'some cases')
+    # This is relative to the xruby root
+    assert_equal '../x-common/exercises/aname', subject.metadata_dir
   end
+
+  def test_initalize_with_fixture_path
+    fixture_path = 'xruby/test/fixtures'
+    subject = Generator.new('aname', 'some cases', fixture_path)
+    assert_equal 'xruby/test/fixtures/exercises/aname', subject.metadata_dir
+  end
+
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,16 @@
+$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
+
+require 'simplecov'
+require 'minitest/autorun'
+require 'minitest/pride'
+
+SimpleCov.start do
+  add_filter '/tests/'
+  add_group 'Utilities' do |file|
+    !(file.filename =~ /_cases\.rb$/)
+  end
+  add_group 'Cases', '_cases.rb'
+end
+
+# So we can be sure we have coverage on the whole lib directory:
+Dir.glob('lib/*.rb').each { |file| require file.gsub(%r{(^lib\/|\.rb$)}, '') }


### PR DESCRIPTION
Adds unit tests for `lib/generator` In order to make development on the test generator easier and less scary.

The tests can be run via: `bundle exec rake test`

In order to get this set up a few other things need to happen:

Add `rake` gem for easy test running.
Add `simplecov` gem to provide test coverage reports.
Create `test/` directory to hold the tests.
Exclude `test/` directory from executable tests check.
Create `test/generator_test.rb` to hold unit tests of `lib/generator.rb`

Once that was done I was able to start writing some unit tests. 

I have added a configurable `metadata_repostitory_path` in order to aid testing by being able to supply a test fixture rather than having to rely on the global x-common data.

Not much else is covered so far this shall be improved in future PRs.



This pull request is ready to merge `bin/generator` will still work (as long as it is run from the xruby root directory.) 

