### PR TITLE
Improve lib/generator test coverage

### DIFF
--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -4,6 +4,14 @@ require 'erb'
 require 'json'
 require 'ostruct'
 
+# Wrap git shell commands.
+class GitCommand
+  def self.short_sha(base_path)
+    git_path = File.join(base_path, '.git')
+    `git --git-dir=#{git_path} log -1 --pretty=format:'%h'`
+  end
+end
+
 class Generator
   METADATA_REPOSITORY = 'x-common'.freeze
 
@@ -47,7 +55,7 @@ class Generator
   end
 
   def sha1
-    `cd #{metadata_dir} && git log -1 --pretty=format:"%h"`
+    GitCommand.short_sha(@metadata_repository_path)
   end
 
   def test_cases

--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -8,14 +8,14 @@ class Generator
   METADATA_REPOSITORY = 'x-common'.freeze
 
   attr_reader :name, :cases
-  def initialize(name, cases, metadata_repository_path=nil)
+  def initialize(name, cases, metadata_repository_path = nil)
     @name = name
     @cases = cases
     @metadata_repository_path = metadata_repository_path || default_metadata_path
   end
 
   def default_metadata_path
-    File.join( '..', METADATA_REPOSITORY)
+    File.join('..', METADATA_REPOSITORY)
   end
 
   def metadata_dir
@@ -27,11 +27,11 @@ class Generator
   end
 
   def exercise_meta_dir
-    File.join(exercise_dir,'.meta')
+    File.join(exercise_dir, '.meta')
   end
 
   def version_filename
-    File.join(exercise_meta_dir,'.version')
+    File.join(exercise_meta_dir, '.version')
   end
 
   def data
@@ -39,7 +39,7 @@ class Generator
   end
 
   def path_to(file)
-    File.join(exercise_dir,file)
+    File.join(exercise_dir, file)
   end
 
   def version

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -18,4 +18,12 @@ class GeneratorTest < Minitest::Test
     # This is relative to the xruby root
     assert_equal 'exercises/aname', subject.exercise_dir
   end
+
+  def test_sha1
+    expected = '1234567'
+    GitCommand.stub :short_sha, expected do
+      subject = Generator.new(nil, nil)
+      assert_equal expected, subject.sha1
+    end
+  end
 end


### PR DESCRIPTION
Add test coverage for `sha1` method

Extracted `GitCommand` class to wrap the required git shell commands.
There's currently only one, `short_sha`.

We're using this instead of a gem because we don't need the full suite of git functionality and:

The 'git' gem is umaintained and doesn't provide short shas.

The 'rugged' gem requires compiling its own libgit2 which seems like an excessive dependency.