### PR TITLE
Add TargetRubyVersion for rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.1
+
 # Type 'Lint' (48):
 Lint/AmbiguousOperator:
   Description: Checks for ambiguous operators in the first argument of a method invocation


### PR DESCRIPTION
In the process of working on some test generators, I ran into a little issue with the current rubocop and using keyword arguments.

Here I just added a target ruby version the rubocop config. I set the target version to `2.1`, but that was only to make keyword arguments. I'm not sure if that's the actual version we want to target, or if it really matters.

Thanks so much for your time!