### PR TITLE
Update README to use Ruby version 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Exercism Exercises in Ruby
 
 ## Setup
 
-You'll need a recent (1.9.3+) version of Ruby, but that's it. Minitest
+You'll need a recent (2.1+) version of Ruby, but that's it. Minitest
 ships
 with the language, so you're all set.
 


### PR DESCRIPTION
Making another PR to update the README based on #511

The [Gemfile](https://github.com/exercism/xruby/blob/master/Gemfile) doesn't specify a Ruby version, but would you like me to add it there? If so, should I use `2.1.2`, which is what CI runs on?