### PR TITLE
Fix typo in SimpleCov filter

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ require 'minitest/autorun'
 require 'minitest/pride'
 
 SimpleCov.start do
-  add_filter '/tests/'
+  add_filter '/test/'
   add_group 'Utilities' do |file|
     !(file.filename =~ /_cases\.rb$/)
   end


### PR DESCRIPTION
Hi there!

I noticed a little typo in the `SimpleCov` configuration that causes test files to not be filtered out.

The effects of this can be reproduced by adding a new test file `foo_test.rb`:

```ruby
require_relative 'test_helper'
```

and running `rake test` to regenerate the coverage map.

This will cause `test/generator_test.rb` to show up under the `Utilities` tab and the `All Files` tab in the coverage web view.