### PR TITLE
Limit rainbow gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'minitest'
+gem 'rainbow', '>= 2.1.0', '< 2.2.0'
 gem 'rubocop', '0.36.0'
 gem 'simplecov'
 gem 'rake'


### PR DESCRIPTION
Looks like a new version of the gem `rainbow` was released today and is causing some problems with our travis builds.

There's an issue already on the rainbow repo at sickill/rainbow#40.

This should ensure that we use rainbow version `2.1.x` and not the currently problematic `2.2.0` version.