### PR TITLE
Add phony target for test in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: test
+
 # assignments
 ASSIGNMENT ?= ""
 IGNOREDIRS := "^(\.git|bin|docs|lib|exercises)$$"
@@ -33,4 +35,3 @@ test:
 	@for assignment in $(ASSIGNMENTS); do \
 		ASSIGNMENT=$$assignment $(MAKE) -s test-assignment || exit 1;\
 	done
-


### PR DESCRIPTION
Hi there!

I noticed while looking at the Travis CI output yesterday that the tests don't appear to be running.

From Travis CI log output:

```
$ make test
```

```
make: `test' is up to date.

The command "make test" exited with 0.
```

This is happening because we added a `test` directory, and the Makefile target is also named `test`.

If this looks good to you all and gets merged, I will rebase and push #514, #510, and #509 to run CI with the tests.

Thanks so much for your time!