### PR TITLE
Remove rainbow from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'minitest'
-gem 'rainbow', '>= 2.1.0', '< 2.2.0'
 gem 'rubocop', '0.36.0'
 gem 'simplecov'
 gem 'rake'


### PR DESCRIPTION
Resolves #517

It looks like rainbow version `2.2.1` has been released and is working for some, but not others (maybe a different issue than the original).

In this PR I removed `rainbow` from the Gemfile and removed the `--queit` flag from `bundle install --quiet` in the Travis config to make sure `2.2.1` was being used and it worked!

I then went ahead and reverted the temporary commit to include a specific version in the Gemfile.

Thanks so much for your time!