### PR TITLE
Run non-exercise tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
 script:
   - rubocop -fs -D
   - bin/executable-tests-check
+  - rake test
   - make test
   - bin/fetch-configlet
   - bin/configlet .

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,15 +1,18 @@
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 
-require 'simplecov'
 require 'minitest/autorun'
 require 'minitest/pride'
 
-SimpleCov.start do
-  add_filter '/test/'
-  add_group 'Utilities' do |file|
-    !(file.filename =~ /_cases\.rb$/)
+unless ENV['CI']
+  require 'simplecov'
+
+  SimpleCov.start do
+    add_filter '/test/'
+    add_group 'Utilities' do |file|
+      !(file.filename =~ /_cases\.rb$/)
+    end
+    add_group 'Cases', '_cases.rb'
   end
-  add_group 'Cases', '_cases.rb'
 end
 
 # So we can be sure we have coverage on the whole lib directory:


### PR DESCRIPTION
This PR adds `rake test` to the travis config to run non-exercise tests in CI as discussed in #519.

Resolves #519.