### PR TITLE
*_cases_tests: Require 'json' module before calling `.to_json`

### DIFF
--- a/test/grains_cases_test.rb
+++ b/test/grains_cases_test.rb
@@ -1,3 +1,4 @@
+require 'json'
 require_relative 'test_helper'
 
 class GrainsTest < Minitest::Test

--- a/test/wordy_cases_test.rb
+++ b/test/wordy_cases_test.rb
@@ -1,3 +1,4 @@
+require 'json'
 require_relative 'test_helper'
 
 class WordyCaseTest < Minitest::Test


### PR DESCRIPTION
These two tests use the `.to_json` method which is defined in the JSON module, which needs to be `require`d before it is used.

Previously they were relying on an unspecified file to have loaded the module for them, but the module was not guaranteed to be loaded before the tests ran so the tests would fail.