### PR TITLE
Move simplecov code before minitest is required

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 
-require 'minitest/autorun'
-require 'minitest/pride'
-
 unless ENV['CI']
   require 'simplecov'
 
@@ -14,6 +11,9 @@ unless ENV['CI']
     add_group 'Cases', '_cases.rb'
   end
 end
+
+require 'minitest/autorun'
+require 'minitest/pride'
 
 # So we can be sure we have coverage on the whole lib directory:
 Dir.glob('lib/*.rb').each { |file| require file.gsub(%r{(^lib\/|\.rb$)}, '') }


### PR DESCRIPTION
Right now, code coverage isn't being generated properly.

This is because `simplecov` is initialized after `minitest/autorun` is required.