### PR TITLE
bin/generate: Default display progress messages.

### DIFF
--- a/lib/generator/command_line.rb
+++ b/lib/generator/command_line.rb
@@ -30,10 +30,10 @@ module Generator
     end
 
     def repository
-      if @options[:verbose]
-        LoggingRepository.new(paths: @paths, exercise_name: @options[:exercise_name], logger: logger)
-      else
+      if @options[:quiet]
         Repository.new(paths: @paths, exercise_name: @options[:exercise_name])
+      else
+        LoggingRepository.new(paths: @paths, exercise_name: @options[:exercise_name], logger: logger)
       end
     end
 
@@ -46,14 +46,14 @@ module Generator
     def logger
       logger = Logger.new($stdout)
       logger.formatter = proc { |_severity, _datetime, _progname, msg| "#{msg}\n" }
-      logger.level = @options[:verbose] ? Logger::DEBUG : Logger::ERROR
+      logger.level = @options[:quiet] ? Logger::ERROR : Logger::DEBUG
       logger
     end
 
     def default_options
       {
         freeze: false,
-        verbose: false,
+        quiet: false,
         exercise_name: nil
       }
     end
@@ -90,7 +90,7 @@ module Generator
         parser.banner = "Usage: #{$PROGRAM_NAME} [options] exercise-generator"
         parser.on('-f', '--freeze', 'Don\'t update test version') { |value| @options[:freeze] = value }
         parser.on('-h', '--help', 'Displays this help message') { |value| @options[:help] = value }
-        parser.on('-v', '--verbose', 'Display progress messages') { |value| @options[:verbose] = value }
+        parser.on('-q', '--quiet', "Don't display progress messages") { |value| @options[:quiet] = value }
       end
     end
 

--- a/test/generator/command_line_test.rb
+++ b/test/generator/command_line_test.rb
@@ -73,8 +73,8 @@ module Generator
       end
     end
 
-    def test_verbose_option
-      args = %w(-v beta)
+    def test_quiet_option
+      args = %w(-q beta)
       Files::GeneratorCases.stub :available, %w(beta) do
         assert_instance_of UpdateVersionAndGenerateTests, CommandLine.new(FixturePaths).parse(args)
       end


### PR DESCRIPTION
Default `bin/generate exercise` to displaying informative progress messages:

```none
$ bin/generate isogram
Incremented tests version to 3
Updated version in example solution to 3
Generated tests for isogram
```

If you want it to be silent use the `--quiet` command line switch.

This patch removes the `--verbose` option and adds `--quiet`