### PR TITLE
bin/generate: Default display success message.

### DIFF
--- a/lib/generator/command_line.rb
+++ b/lib/generator/command_line.rb
@@ -30,11 +30,10 @@ module Generator
     end
 
     def repository
-      if @options[:verbose]
-        LoggingRepository.new(paths: @paths, exercise_name: @options[:exercise_name], logger: logger)
-      else
-        Repository.new(paths: @paths, exercise_name: @options[:exercise_name])
-      end
+      LoggingRepository.new(
+        repository: Repository.new(paths: @paths, exercise_name: @options[:exercise_name]),
+        logger: logger
+      )
     end
 
     def parse_options(args)
@@ -46,7 +45,7 @@ module Generator
     def logger
       logger = Logger.new($stdout)
       logger.formatter = proc { |_severity, _datetime, _progname, msg| "#{msg}\n" }
-      logger.level = @options[:verbose] ? Logger::DEBUG : Logger::ERROR
+      logger.level = @options[:verbose] ? Logger::DEBUG : Logger::INFO
       logger
     end
 

--- a/lib/generator/repository.rb
+++ b/lib/generator/repository.rb
@@ -30,33 +30,33 @@ module Generator
         template: tests_template.to_s,
         values: template_values
       )
-      display_result
-    end
-
-    def display_result
-      $stdout.puts "Generated #{exercise_name} tests version #{version}"
-    end
-  end
-
-  # A repository that also logs its progress.
-  class LoggingRepository < Repository
-    def initialize(paths:, exercise_name:, logger:)
-      super(paths: paths, exercise_name: exercise_name)
-      @logger = logger
-    end
-
-    def update_tests_version
-      super
-      @logger.info "Incremented tests version to #{version}"
-    end
-
-    def update_example_solution
-      super
-      @logger.info "Updated version in example solution to #{version}"
     end
   end
 
   # This exists to give us a clue as to what we are delegating to.
   class RepositoryDelegator < SimpleDelegator
+  end
+
+  # A repository that also logs its progress.
+  class LoggingRepository < RepositoryDelegator
+    def initialize(repository:, logger:)
+      __setobj__ @repository = repository
+      @logger = logger
+    end
+
+    def update_tests_version
+      @repository.update_tests_version
+      @logger.debug "Incremented tests version to #{version}"
+    end
+
+    def update_example_solution
+      @repository.update_example_solution
+      @logger.debug "Updated version in example solution to #{version}"
+    end
+
+    def create_tests_file
+      @repository.create_tests_file
+      @logger.info "Generated #{exercise_name} tests version #{version}"
+    end
   end
 end

--- a/lib/generator/repository.rb
+++ b/lib/generator/repository.rb
@@ -30,6 +30,11 @@ module Generator
         template: tests_template.to_s,
         values: template_values
       )
+      display_result
+    end
+
+    def display_result
+      $stdout.puts "Generated #{exercise_name} tests version #{version}"
     end
   end
 
@@ -48,11 +53,6 @@ module Generator
     def update_example_solution
       super
       @logger.info "Updated version in example solution to #{version}"
-    end
-
-    def create_tests_file
-      super
-      @logger.info "Generated tests for #{exercise_name}"
     end
   end
 

--- a/test/generator/repository_test.rb
+++ b/test/generator/repository_test.rb
@@ -41,56 +41,50 @@ module Generator
       subject.define_singleton_method(:minitest_tests) { mock_minitest_tests }
       subject.define_singleton_method(:tests_template) { mock_tests_template }
       subject.define_singleton_method(:template_values) { mock_template_values }
-      expected = "Generated alpha tests version 1\n"
-      assert_output(expected,nil) do
-        subject.create_tests_file
-      end
+      subject.create_tests_file
       mock_minitest_tests.verify
-    end
-
-    def test_display_result
-      fake_version = 2
-      subject = Repository.new(paths: FixturePaths, exercise_name: 'alpha')
-      subject.define_singleton_method(:version) { fake_version }
-      expected = "Generated alpha tests version 2\n"
-      assert_output(expected, nil) do
-        subject.display_result
-      end
     end
   end
 
   class LoggingRepositoryTest < Minitest::Test
-    FixturePaths = Paths.new(
-      metadata: 'test/fixtures/metadata',
-      track: 'test/fixtures/xruby'
-    )
+    def test_create_tests_file
+      mock_repository = Minitest::Mock.new
+      mock_repository.expect :create_tests_file, nil
+      mock_repository.expect :exercise_name, 'alpha'
+      mock_repository.expect :version, 2
+      mock_logger = Minitest::Mock.new
+      mock_logger.expect :info, nil, ['Generated alpha tests version 2']
+
+      subject = LoggingRepository.new(repository: mock_repository, logger: mock_logger)
+      subject.create_tests_file
+
+      mock_repository.verify
+    end
 
     def test_update_tests_version
-      fake_version = 2
-
+      mock_repository = Minitest::Mock.new
+      mock_repository.expect :update_tests_version, nil
+      mock_repository.expect :version, 2
       mock_logger = Minitest::Mock.new
-      mock_logger.expect :info, nil, ["Incremented tests version to #{fake_version}"]
+      mock_logger.expect :debug, nil, ['Incremented tests version to 2']
 
-      mock_tests_version = Minitest::Mock.new.expect :increment, fake_version
-      subject = LoggingRepository.new(paths: FixturePaths, exercise_name: 'alpha', logger: mock_logger)
-      subject.define_singleton_method(:tests_version) { mock_tests_version }
-      subject.define_singleton_method(:version) { fake_version }
+      subject = LoggingRepository.new(repository: mock_repository, logger: mock_logger)
       subject.update_tests_version
-      mock_logger.verify
+
+      mock_repository.verify
     end
 
     def test_update_example_solution
-      fake_version = 2
+      mock_repository = Minitest::Mock.new
+      mock_repository.expect :update_example_solution, nil
+      mock_repository.expect :version, 2
       mock_logger = Minitest::Mock.new
-      mock_logger.expect :info, nil, ["Updated version in example solution to #{fake_version}"]
+      mock_logger.expect :debug, nil, ['Updated version in example solution to 2']
 
-      mock_example_solution = Minitest::Mock.new.expect :update_version, nil, [2]
-      subject = LoggingRepository.new(paths: FixturePaths, exercise_name: 'alpha', logger: mock_logger)
-      subject.define_singleton_method(:example_solution) { mock_example_solution }
-      subject.define_singleton_method(:version) { fake_version }
-
+      subject = LoggingRepository.new(repository: mock_repository, logger: mock_logger)
       subject.update_example_solution
-      mock_logger.verify
+
+      mock_repository.verify
     end
   end
 end

--- a/test/generator/repository_test.rb
+++ b/test/generator/repository_test.rb
@@ -41,8 +41,21 @@ module Generator
       subject.define_singleton_method(:minitest_tests) { mock_minitest_tests }
       subject.define_singleton_method(:tests_template) { mock_tests_template }
       subject.define_singleton_method(:template_values) { mock_template_values }
-      subject.create_tests_file
+      expected = "Generated alpha tests version 1\n"
+      assert_output(expected,nil) do
+        subject.create_tests_file
+      end
       mock_minitest_tests.verify
+    end
+
+    def test_display_result
+      fake_version = 2
+      subject = Repository.new(paths: FixturePaths, exercise_name: 'alpha')
+      subject.define_singleton_method(:version) { fake_version }
+      expected = "Generated alpha tests version 2\n"
+      assert_output(expected, nil) do
+        subject.display_result
+      end
     end
   end
 
@@ -77,21 +90,6 @@ module Generator
       subject.define_singleton_method(:version) { fake_version }
 
       subject.update_example_solution
-      mock_logger.verify
-    end
-
-    # Too much to set up here :(
-    def test_create_tests_file
-      mock_logger = Minitest::Mock.new.expect :info, nil, ['Generated tests for alpha']
-
-      mock_tests_template = Minitest::Mock.new.expect :to_s, 'template'
-      mock_template_values = Minitest::Mock.new
-      mock_minitest_tests = Minitest::Mock.new.expect :generate, nil, [{ template: 'template', values: mock_template_values }]
-      subject = LoggingRepository.new(paths: FixturePaths, exercise_name: 'alpha', logger: mock_logger)
-      subject.define_singleton_method(:minitest_tests) { mock_minitest_tests }
-      subject.define_singleton_method(:tests_template) { mock_tests_template }
-      subject.define_singleton_method(:template_values) { mock_template_values }
-      subject.create_tests_file
       mock_logger.verify
     end
   end


### PR DESCRIPTION
The old behavior was:

```
$ bin/generate isogram
$
```

Which is not particularly friendly or helpful. Did it even do anything?

The new default behavior is to report success to stdout:
```
$ bin/generate isogram
Generated isogram tests version 3
$
```

The original behavior can be replicated by redirecting stdout to /dev/null
```
$ bin/generate isogram > /dev/null
$
```

The `-v` option still provides additional information.
```
$ bin/generate -v isogram
Incremented tests version to 4
Updated version in example solution to 4
Generated isogram tests version 4
```