### PR TITLE
rake task tests: Fix Ruby warnings due to private attr_reader.

### DIFF
--- a/lib/tasks/exercise_test_tasks.rb
+++ b/lib/tasks/exercise_test_tasks.rb
@@ -21,10 +21,8 @@ class ExerciseTestTasks
 
   private
 
-  attr_reader :options, :test_runner
-
   def exercises
-    @_exercises ||= Exercise.all
+    @exercises ||= Exercise.all
   end
 
   def define_task_for_all_exercises
@@ -34,7 +32,7 @@ class ExerciseTestTasks
 
   def define_task_for(exercise)
     task exercise do
-      test_runner.new(exercise: exercise, test_options: options).run
+      @test_runner.new(exercise: exercise, test_options: @options).run
     end
   end
 end

--- a/lib/tasks/exercise_tests_runner.rb
+++ b/lib/tasks/exercise_tests_runner.rb
@@ -1,4 +1,4 @@
-require "rake/file_utils_ext"
+require 'rake/file_utils_ext'
 require 'tmpdir'
 
 class ExerciseTestsRunner
@@ -10,9 +10,9 @@ class ExerciseTestsRunner
   end
 
   def run
-    puts "\n\n#{'-'*64}\nrunning tests for: #{exercise}"
+    puts "\n\n#{'-' * 64}\nrunning tests for: #{@exercise}"
 
-    Dir.mktmpdir(exercise.name) do |dir|
+    Dir.mktmpdir(@exercise.name) do |dir|
       setup_exercise_files_in(dir)
       run_exercise_tests_in(dir)
     end
@@ -20,14 +20,12 @@ class ExerciseTestsRunner
 
   private
 
-  attr_reader :exercise, :test_options
-
   def setup_exercise_files_in(dir)
-    FileUtils.cp_r exercise.directory, dir
-    FileUtils.mv "#{dir}/#{exercise.example_file}", "#{dir}/#{exercise.testable_example_file}"
+    FileUtils.cp_r @exercise.directory, dir
+    FileUtils.mv "#{dir}/#{@exercise.example_file}", "#{dir}/#{@exercise.testable_example_file}"
   end
 
   def run_exercise_tests_in(dir)
-    ruby "-I lib -r disable_skip.rb #{dir}/#{exercise.test_file} #{test_options}"
+    ruby "-I lib -r disable_skip.rb #{dir}/#{@exercise.test_file} #{@test_options}"
   end
 end


### PR DESCRIPTION
Replaced private attr_reader methods with direct instance variable access. This is not as elegant as the attr_reader version, but does not generate interpreter warnings.

The warnings were:
```
xruby/lib/tasks/exercise_tests_runner.rb:23: warning: private attribute?
xruby/lib/tasks/exercise_tests_runner.rb:23: warning: private attribute?
xruby/lib/tasks/exercise_test_tasks.rb:24: warning: private attribute?
xruby/lib/tasks/exercise_test_tasks.rb:24: warning: private attribute?
```

These warnings are present in Ruby versions < 2.3.0