### PR TITLE
bin/generator: Remove version compensation.

### DIFF
--- a/exercises/acronym/example.tt
+++ b/exercises/acronym/example.tt
@@ -14,6 +14,6 @@ class AcronymTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/all-your-base/example.tt
+++ b/exercises/all-your-base/example.tt
@@ -12,6 +12,6 @@ class AllYourBaseTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/alphametics/example.tt
+++ b/exercises/alphametics/example.tt
@@ -17,6 +17,6 @@ class AlphameticsTest < Minitest::Test
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/anagram/example.tt
+++ b/exercises/anagram/example.tt
@@ -14,6 +14,6 @@ class AnagramTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/binary/example.tt
+++ b/exercises/binary/example.tt
@@ -15,6 +15,6 @@ class BinaryTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/bowling/example.tt
+++ b/exercises/bowling/example.tt
@@ -24,6 +24,6 @@ class BowlingTest < Minitest::Test
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/bracket-push/example.tt
+++ b/exercises/bracket-push/example.tt
@@ -14,6 +14,6 @@ class BracketsTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/clock/example.tt
+++ b/exercises/clock/example.tt
@@ -14,6 +14,6 @@ class ClockTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/custom-set/example.tt
+++ b/exercises/custom-set/example.tt
@@ -14,6 +14,6 @@ class CustomSetTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/difference-of-squares/example.tt
+++ b/exercises/difference-of-squares/example.tt
@@ -19,6 +19,6 @@ class DifferenceOfSquaresTest < Minitest::Test<% test_cases.each do |test_case| 
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/dominoes/example.tt
+++ b/exercises/dominoes/example.tt
@@ -15,7 +15,7 @@ class DominoesTest < Minitest::Test
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 
   # It's infeasible to use example-based tests for this exercise,

--- a/exercises/gigasecond/example.tt
+++ b/exercises/gigasecond/example.tt
@@ -17,6 +17,6 @@ class GigasecondTest < Minitest::Test<% test_cases.each do |test_case| %>
 
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/grains/example.tt
+++ b/exercises/grains/example.tt
@@ -12,6 +12,6 @@ class GrainsTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/hamming/example.tt
+++ b/exercises/hamming/example.tt
@@ -15,6 +15,6 @@ class HammingTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/isogram/example.tt
+++ b/exercises/isogram/example.tt
@@ -15,6 +15,6 @@ class IsogramTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/largest-series-product/example.tt
+++ b/exercises/largest-series-product/example.tt
@@ -15,6 +15,6 @@ class Seriestest < Minitest::Test<% test_cases.each do |test_case| %>
 <% end %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/leap/example.tt
+++ b/exercises/leap/example.tt
@@ -24,6 +24,6 @@ class YearTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/nth-prime/example.tt
+++ b/exercises/nth-prime/example.tt
@@ -16,6 +16,6 @@ class NthPrimeTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/pangram/example.tt
+++ b/exercises/pangram/example.tt
@@ -15,6 +15,6 @@ class PangramTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/queen-attack/example.tt
+++ b/exercises/queen-attack/example.tt
@@ -17,6 +17,6 @@ class QueenTest < Minitest::Test
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/raindrops/example.tt
+++ b/exercises/raindrops/example.tt
@@ -14,6 +14,6 @@ class RaindropsTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/rna-transcription/example.tt
+++ b/exercises/rna-transcription/example.tt
@@ -14,6 +14,6 @@ class ComplementTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/roman-numerals/example.tt
+++ b/exercises/roman-numerals/example.tt
@@ -14,6 +14,6 @@ class RomanNumeralsTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/run-length-encoding/example.tt
+++ b/exercises/run-length-encoding/example.tt
@@ -17,6 +17,6 @@ class RunLengthEncodingTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/sieve/example.tt
+++ b/exercises/sieve/example.tt
@@ -16,6 +16,6 @@ class SieveTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/tournament/example.tt
+++ b/exercises/tournament/example.tt
@@ -18,6 +18,6 @@ class TournamentTest < Minitest::Test
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/transpose/example.tt
+++ b/exercises/transpose/example.tt
@@ -17,6 +17,6 @@ class TransposeTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/triangle/example.tt
+++ b/exercises/triangle/example.tt
@@ -14,7 +14,7 @@ class TriangleTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end
 

--- a/exercises/two-bucket/example.tt
+++ b/exercises/two-bucket/example.tt
@@ -14,6 +14,6 @@ class TwoBucketTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/word-count/example.tt
+++ b/exercises/word-count/example.tt
@@ -16,7 +16,7 @@ class PhraseTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end
 

--- a/exercises/wordy/example.tt
+++ b/exercises/wordy/example.tt
@@ -12,6 +12,6 @@ class WordyTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -22,14 +22,10 @@ module Generator
       require 'json'
       require cases_require_name
 
-      # Compensate for the version.next that appears in template files.
-      # TODO: remove the .next from the template files and remove compensation
-      compensated_version = version - 1
-
       TemplateValues.new(
         # TODO: rename sha1 to abbreviated_commit_hash
         sha1: canonical_data.abbreviated_commit_hash,
-        version: compensated_version,
+        version: version,
         test_cases: test_cases_proc.call(canonical_data.to_s)
       )
     end

--- a/test/fixtures/xruby/exercises/alpha/example.tt
+++ b/test/fixtures/xruby/exercises/alpha/example.tt
@@ -15,6 +15,6 @@ class AlphaTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end


### PR DESCRIPTION
All the test templates were updating the version:
```
assert_equal <%= version.next %>, BookKeeping::VERSION
```

But the responsibility for mainlining the template version belongs with the generator, not the template.

So we update the template to use the version passed to it:
```
assert_equal <%= version %>, BookKeeping::VERSION
```

And once the templates have been updated, we can delete the [code required to compensate](https://github.com/exercism/xruby/compare/master...Insti:Remove_version_compensation?expand=1#diff-35b0b1d4ffa097f11ffe659d2ee3398d)  for the version incrementing.

