### PR TITLE
bin/generator: Fix outstanding TODOs

### DIFF
--- a/exercises/acronym/example.tt
+++ b/exercises/acronym/example.tt
@@ -14,6 +14,6 @@ class AcronymTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/acronym/example.tt
+++ b/exercises/acronym/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'acronym'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class AcronymTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/acronym/example.tt
+++ b/exercises/acronym/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'acronym'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class AcronymTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/all-your-base/example.tt
+++ b/exercises/all-your-base/example.tt
@@ -12,6 +12,6 @@ class AllYourBaseTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/all-your-base/example.tt
+++ b/exercises/all-your-base/example.tt
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'all_your_base'
 
-# Test data version: <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class AllYourBaseTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/all-your-base/example.tt
+++ b/exercises/all-your-base/example.tt
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'all_your_base'
 
-# Test data version: <%= sha1 %>
+# Test data version: <%= abbreviated_commit_hash %>
 class AllYourBaseTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/alphametics/example.tt
+++ b/exercises/alphametics/example.tt
@@ -3,7 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'alphametics'
 
-# Test data version: <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class AlphameticsTest < Minitest::Test
 <% test_cases.each do |test_case| %>
 

--- a/exercises/alphametics/example.tt
+++ b/exercises/alphametics/example.tt
@@ -3,7 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'alphametics'
 
-# Test data version: <%= sha1 %>
+# Test data version: <%= abbreviated_commit_hash %>
 class AlphameticsTest < Minitest::Test
 <% test_cases.each do |test_case| %>
 

--- a/exercises/alphametics/example.tt
+++ b/exercises/alphametics/example.tt
@@ -17,6 +17,6 @@ class AlphameticsTest < Minitest::Test
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/anagram/example.tt
+++ b/exercises/anagram/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'anagram'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class AnagramTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/anagram/example.tt
+++ b/exercises/anagram/example.tt
@@ -14,6 +14,6 @@ class AnagramTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/anagram/example.tt
+++ b/exercises/anagram/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'anagram'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class AnagramTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/binary/example.tt
+++ b/exercises/binary/example.tt
@@ -15,6 +15,6 @@ class BinaryTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/binary/example.tt
+++ b/exercises/binary/example.tt
@@ -5,7 +5,7 @@ require 'minitest/autorun'
 require_relative 'binary'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class BinaryTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %>

--- a/exercises/binary/example.tt
+++ b/exercises/binary/example.tt
@@ -4,8 +4,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'binary'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class BinaryTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %>

--- a/exercises/bowling/example.tt
+++ b/exercises/bowling/example.tt
@@ -3,7 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'bowling'
 
-# Test data version: <%= sha1 %>
+# Test data version: <%= abbreviated_commit_hash %>
 #
 class BowlingTest < Minitest::Test
   def setup

--- a/exercises/bowling/example.tt
+++ b/exercises/bowling/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'bowling'
 
-# Test data version: <%= abbreviated_commit_hash %>
-#
+# Common test data version: <%= abbreviated_commit_hash %>
 class BowlingTest < Minitest::Test
   def setup
     @game = Game.new

--- a/exercises/bowling/example.tt
+++ b/exercises/bowling/example.tt
@@ -24,6 +24,6 @@ class BowlingTest < Minitest::Test
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/bracket-push/example.tt
+++ b/exercises/bracket-push/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'bracket_push'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class BracketsTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %>

--- a/exercises/bracket-push/example.tt
+++ b/exercises/bracket-push/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'bracket_push'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class BracketsTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %>

--- a/exercises/bracket-push/example.tt
+++ b/exercises/bracket-push/example.tt
@@ -14,6 +14,6 @@ class BracketsTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/clock/example.tt
+++ b/exercises/clock/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'clock'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class ClockTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %>

--- a/exercises/clock/example.tt
+++ b/exercises/clock/example.tt
@@ -14,6 +14,6 @@ class ClockTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/clock/example.tt
+++ b/exercises/clock/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'clock'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class ClockTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %>

--- a/exercises/connect/example.tt
+++ b/exercises/connect/example.tt
@@ -3,7 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'connect'
 
-# Test data version commit id: <%= sha1 %>
+# Test data version commit id: <%= abbreviated_commit_hash %>
 class ConnectTest < Minitest::Test<% test_cases.each do |test_case| %>
   <%= test_case.ignore_method_length%>def <%= test_case.name %>
     <%= test_case.skipped %><% test_case.test_body.each do |line| %>

--- a/exercises/connect/example.tt
+++ b/exercises/connect/example.tt
@@ -3,7 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'connect'
 
-# Test data version commit id: <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class ConnectTest < Minitest::Test<% test_cases.each do |test_case| %>
   <%= test_case.ignore_method_length%>def <%= test_case.name %>
     <%= test_case.skipped %><% test_case.test_body.each do |line| %>

--- a/exercises/custom-set/example.tt
+++ b/exercises/custom-set/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'custom_set'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class CustomSetTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %>

--- a/exercises/custom-set/example.tt
+++ b/exercises/custom-set/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'custom_set'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class CustomSetTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %>

--- a/exercises/custom-set/example.tt
+++ b/exercises/custom-set/example.tt
@@ -14,6 +14,6 @@ class CustomSetTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/difference-of-squares/example.tt
+++ b/exercises/difference-of-squares/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'difference_of_squares'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class DifferenceOfSquaresTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/difference-of-squares/example.tt
+++ b/exercises/difference-of-squares/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'difference_of_squares'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class DifferenceOfSquaresTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/difference-of-squares/example.tt
+++ b/exercises/difference-of-squares/example.tt
@@ -19,6 +19,6 @@ class DifferenceOfSquaresTest < Minitest::Test<% test_cases.each do |test_case| 
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/dominoes/example.tt
+++ b/exercises/dominoes/example.tt
@@ -3,7 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'dominoes'
 
-# Test data version: <%= sha1 %>
+# Test data version: <%= abbreviated_commit_hash %>
 class DominoesTest < Minitest::Test
 <% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>

--- a/exercises/dominoes/example.tt
+++ b/exercises/dominoes/example.tt
@@ -3,7 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'dominoes'
 
-# Test data version: <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class DominoesTest < Minitest::Test
 <% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>

--- a/exercises/dominoes/example.tt
+++ b/exercises/dominoes/example.tt
@@ -15,7 +15,7 @@ class DominoesTest < Minitest::Test
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 
   # It's infeasible to use example-based tests for this exercise,

--- a/exercises/gigasecond/example.tt
+++ b/exercises/gigasecond/example.tt
@@ -1,8 +1,7 @@
 require 'minitest/autorun'
 require_relative 'gigasecond'
 
-# Test data version: <%= abbreviated_commit_hash %>
-
+# Common test data version: <%= abbreviated_commit_hash %>
 class GigasecondTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/gigasecond/example.tt
+++ b/exercises/gigasecond/example.tt
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'gigasecond'
 
-# Test data version: <%= sha1 %>
+# Test data version: <%= abbreviated_commit_hash %>
 
 class GigasecondTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>

--- a/exercises/gigasecond/example.tt
+++ b/exercises/gigasecond/example.tt
@@ -17,6 +17,6 @@ class GigasecondTest < Minitest::Test<% test_cases.each do |test_case| %>
 
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/grains/example.tt
+++ b/exercises/grains/example.tt
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'grains'
 
-# Test data version: <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class GrainsTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/grains/example.tt
+++ b/exercises/grains/example.tt
@@ -12,6 +12,6 @@ class GrainsTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/grains/example.tt
+++ b/exercises/grains/example.tt
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'grains'
 
-# Test data version: <%= sha1 %>
+# Test data version: <%= abbreviated_commit_hash %>
 class GrainsTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/hamming/example.tt
+++ b/exercises/hamming/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'hamming'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class HammingTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %><% if test_case.raises_error? %>

--- a/exercises/hamming/example.tt
+++ b/exercises/hamming/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'hamming'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class HammingTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %><% if test_case.raises_error? %>

--- a/exercises/hamming/example.tt
+++ b/exercises/hamming/example.tt
@@ -15,6 +15,6 @@ class HammingTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/hello-world/example.tt
+++ b/exercises/hello-world/example.tt
@@ -13,7 +13,7 @@ rescue LoadError => e
 end
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class HelloWorldTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/hello-world/example.tt
+++ b/exercises/hello-world/example.tt
@@ -12,8 +12,7 @@ rescue LoadError => e
   exit 1
 end
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class HelloWorldTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/isogram/example.tt
+++ b/exercises/isogram/example.tt
@@ -15,6 +15,6 @@ class IsogramTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/isogram/example.tt
+++ b/exercises/isogram/example.tt
@@ -4,7 +4,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'isogram'
 
-# Common test data version: <%= sha1 %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class IsogramTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skip %>

--- a/exercises/largest-series-product/example.tt
+++ b/exercises/largest-series-product/example.tt
@@ -3,9 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'largest_series_product'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
-#
+# Common test data version: <%= abbreviated_commit_hash %>
 class Seriestest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %><% if test_case.raises_error? %>

--- a/exercises/largest-series-product/example.tt
+++ b/exercises/largest-series-product/example.tt
@@ -15,6 +15,6 @@ class Seriestest < Minitest::Test<% test_cases.each do |test_case| %>
 <% end %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/largest-series-product/example.tt
+++ b/exercises/largest-series-product/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'largest_series_product'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 #
 class Seriestest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>

--- a/exercises/leap/example.tt
+++ b/exercises/leap/example.tt
@@ -24,6 +24,6 @@ class YearTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/leap/example.tt
+++ b/exercises/leap/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'leap'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class Date
   def leap?
     raise RuntimeError, "Implement this yourself instead of using Ruby's implementation."

--- a/exercises/leap/example.tt
+++ b/exercises/leap/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'leap'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class Date
   def leap?
     raise RuntimeError, "Implement this yourself instead of using Ruby's implementation."

--- a/exercises/nth-prime/example.tt
+++ b/exercises/nth-prime/example.tt
@@ -3,9 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'nth_prime'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
-#
+# Common test data version: <%= abbreviated_commit_hash %>
 class NthPrimeTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %><% if test_case.raises_error? %>

--- a/exercises/nth-prime/example.tt
+++ b/exercises/nth-prime/example.tt
@@ -16,6 +16,6 @@ class NthPrimeTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/nth-prime/example.tt
+++ b/exercises/nth-prime/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'nth_prime'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 #
 class NthPrimeTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>

--- a/exercises/pangram/example.tt
+++ b/exercises/pangram/example.tt
@@ -4,7 +4,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'pangram'
 
-# Test data version: # <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class PangramTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped? %>

--- a/exercises/pangram/example.tt
+++ b/exercises/pangram/example.tt
@@ -4,7 +4,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'pangram'
 
-# Test data version: # <%= sha1 %>
+# Test data version: # <%= abbreviated_commit_hash %>
 class PangramTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped? %>

--- a/exercises/pangram/example.tt
+++ b/exercises/pangram/example.tt
@@ -15,6 +15,6 @@ class PangramTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/queen-attack/example.tt
+++ b/exercises/queen-attack/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'queen_attack'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class QueenTest < Minitest::Test
 
 <% test_cases.each do |test_case| %>

--- a/exercises/queen-attack/example.tt
+++ b/exercises/queen-attack/example.tt
@@ -17,6 +17,6 @@ class QueenTest < Minitest::Test
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/queen-attack/example.tt
+++ b/exercises/queen-attack/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'queen_attack'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class QueenTest < Minitest::Test
 
 <% test_cases.each do |test_case| %>

--- a/exercises/raindrops/example.tt
+++ b/exercises/raindrops/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'raindrops'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class RaindropsTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/raindrops/example.tt
+++ b/exercises/raindrops/example.tt
@@ -14,6 +14,6 @@ class RaindropsTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/raindrops/example.tt
+++ b/exercises/raindrops/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'raindrops'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class RaindropsTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/rna-transcription/example.tt
+++ b/exercises/rna-transcription/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'rna_transcription'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class ComplementTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/rna-transcription/example.tt
+++ b/exercises/rna-transcription/example.tt
@@ -14,6 +14,6 @@ class ComplementTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/rna-transcription/example.tt
+++ b/exercises/rna-transcription/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'rna_transcription'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class ComplementTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/roman-numerals/example.tt
+++ b/exercises/roman-numerals/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'roman_numerals'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class RomanNumeralsTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/roman-numerals/example.tt
+++ b/exercises/roman-numerals/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'roman_numerals'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class RomanNumeralsTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/roman-numerals/example.tt
+++ b/exercises/roman-numerals/example.tt
@@ -14,6 +14,6 @@ class RomanNumeralsTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/run-length-encoding/example.tt
+++ b/exercises/run-length-encoding/example.tt
@@ -17,6 +17,6 @@ class RunLengthEncodingTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/run-length-encoding/example.tt
+++ b/exercises/run-length-encoding/example.tt
@@ -4,8 +4,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'run_length_encoding'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class RunLengthEncodingTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/run-length-encoding/example.tt
+++ b/exercises/run-length-encoding/example.tt
@@ -5,7 +5,7 @@ require 'minitest/autorun'
 require_relative 'run_length_encoding'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class RunLengthEncodingTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/sieve/example.tt
+++ b/exercises/sieve/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'sieve'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 
 class SieveTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>

--- a/exercises/sieve/example.tt
+++ b/exercises/sieve/example.tt
@@ -3,9 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'sieve'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
-
+# Common test data version: <%= abbreviated_commit_hash %>
 class SieveTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %>

--- a/exercises/sieve/example.tt
+++ b/exercises/sieve/example.tt
@@ -16,6 +16,6 @@ class SieveTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/tournament/example.tt
+++ b/exercises/tournament/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'tournament'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class TournamentTest < Minitest::Test
 <% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>

--- a/exercises/tournament/example.tt
+++ b/exercises/tournament/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'tournament'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class TournamentTest < Minitest::Test
 <% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>

--- a/exercises/tournament/example.tt
+++ b/exercises/tournament/example.tt
@@ -18,6 +18,6 @@ class TournamentTest < Minitest::Test
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/transpose/example.tt
+++ b/exercises/transpose/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'transpose'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class TransposeTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/transpose/example.tt
+++ b/exercises/transpose/example.tt
@@ -17,6 +17,6 @@ class TransposeTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/transpose/example.tt
+++ b/exercises/transpose/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'transpose'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class TransposeTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/triangle/example.tt
+++ b/exercises/triangle/example.tt
@@ -14,7 +14,7 @@ class TriangleTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end
 

--- a/exercises/triangle/example.tt
+++ b/exercises/triangle/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'triangle'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class TriangleTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/triangle/example.tt
+++ b/exercises/triangle/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'triangle'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class TriangleTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/two-bucket/example.tt
+++ b/exercises/two-bucket/example.tt
@@ -14,6 +14,6 @@ class TwoBucketTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/exercises/two-bucket/example.tt
+++ b/exercises/two-bucket/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'two_bucket'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class TwoBucketTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/two-bucket/example.tt
+++ b/exercises/two-bucket/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'two_bucket'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class TwoBucketTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/word-count/example.tt
+++ b/exercises/word-count/example.tt
@@ -3,8 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'word_count'
 
-# Test data version:
-# <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class PhraseTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/word-count/example.tt
+++ b/exercises/word-count/example.tt
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require_relative 'word_count'
 
 # Test data version:
-# <%= sha1 %>
+# <%= abbreviated_commit_hash %>
 class PhraseTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %><% if test_case.skipped? %>
     skip<% end %>

--- a/exercises/word-count/example.tt
+++ b/exercises/word-count/example.tt
@@ -16,7 +16,7 @@ class PhraseTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end
 

--- a/exercises/wordy/example.tt
+++ b/exercises/wordy/example.tt
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'wordy'
 
-# Test data version: <%= sha1 %>
+# Test data version: <%= abbreviated_commit_hash %>
 class WordyTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/wordy/example.tt
+++ b/exercises/wordy/example.tt
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'wordy'
 
-# Test data version: <%= abbreviated_commit_hash %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class WordyTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>

--- a/exercises/wordy/example.tt
+++ b/exercises/wordy/example.tt
@@ -12,6 +12,6 @@ class WordyTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/lib/acronym_cases.rb
+++ b/lib/acronym_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class AcronymCase < OpenStruct
   def name
     'test_%s' % description.tr(' ', '_')

--- a/lib/all_your_base_cases.rb
+++ b/lib/all_your_base_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class AllYourBaseCase < OpenStruct
   def test_name
     'test_%s' % description.downcase.tr(' -', '_')

--- a/lib/alphametics_cases.rb
+++ b/lib/alphametics_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class AlphameticsCase < OpenStruct
   def test_name
     "test_#{description.tr(' ', '_')}"

--- a/lib/anagram_cases.rb
+++ b/lib/anagram_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class AnagramCase < OpenStruct
   def test_name
     'test_%s' % description.gsub(/[ -]/, '_')

--- a/lib/binary_cases.rb
+++ b/lib/binary_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class BinaryCase < OpenStruct
   def name
     'test_%s' % description.gsub(/[ -]/, '_')

--- a/lib/bowling_cases.rb
+++ b/lib/bowling_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class BowlingCase < OpenStruct
   def test_name
     "test_#{description.downcase.tr(' ', '_')}"

--- a/lib/bracket_push_cases.rb
+++ b/lib/bracket_push_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class BracketPushCase < OpenStruct
   def name
     'test_%s' % description.gsub(/[ -]/, '_')

--- a/lib/clock_cases.rb
+++ b/lib/clock_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class ClockCase < OpenStruct
   def name
     'test_%s' % description

--- a/lib/connect_cases.rb
+++ b/lib/connect_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class ConnectCase < OpenStruct
   def name
     'test_%s' % description

--- a/lib/custom_set_cases.rb
+++ b/lib/custom_set_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class CustomSetCase < OpenStruct
   def name
     'test_%s' % description.gsub(/ |-/, '_')

--- a/lib/difference_of_squares_cases.rb
+++ b/lib/difference_of_squares_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class DifferenceOfSquaresCase < OpenStruct
   def test_name
     'test_%s' % description.gsub(/[ -]/, '_')

--- a/lib/dominoes_cases.rb
+++ b/lib/dominoes_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class DominoesCase < OpenStruct
   def test_name
     'test_%s' % description.gsub("can't", 'can not').gsub(/[= -]+/, '_')

--- a/lib/exercise_cases.rb
+++ b/lib/exercise_cases.rb
@@ -1,0 +1,2 @@
+require 'ostruct'
+require 'json'

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -22,14 +22,10 @@ module Generator
       require 'json'
       require cases_require_name
 
-      # Compensate for the version.next that appears in template files.
-      # TODO: remove the .next from the template files and remove compensation
-      compensated_version = version - 1
-
       TemplateValues.new(
         # TODO: rename sha1 to abbreviated_commit_hash
         sha1: canonical_data.abbreviated_commit_hash,
-        version: compensated_version,
+        version: version,
         test_cases: test_cases_proc.call(canonical_data.to_s)
       )
     end

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -1,10 +1,10 @@
 module Generator
   # Contains methods accessible to the ERB template
   class TemplateValues
-    attr_reader :sha1, :version, :test_cases
+    attr_reader :abbreviated_commit_hash, :version, :test_cases
 
-    def initialize(sha1:, version:, test_cases:)
-      @sha1 = sha1
+    def initialize(abbreviated_commit_hash:, version:, test_cases:)
+      @abbreviated_commit_hash = abbreviated_commit_hash
       @version = version
       @test_cases = test_cases
     end
@@ -23,8 +23,7 @@ module Generator
       require cases_require_name
 
       TemplateValues.new(
-        # TODO: rename sha1 to abbreviated_commit_hash
-        sha1: canonical_data.abbreviated_commit_hash,
+        abbreviated_commit_hash: canonical_data.abbreviated_commit_hash,
         version: version,
         test_cases: test_cases_proc.call(canonical_data.to_s)
       )

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -16,10 +16,6 @@ module Generator
 
   module TemplateValuesFactory
     def template_values
-      # These are needed by the 'ExerciseCases' classes
-      # TODO: move these into the individual classes
-      require 'ostruct'
-      require 'json'
       require cases_require_name
 
       TemplateValues.new(

--- a/lib/gigasecond_cases.rb
+++ b/lib/gigasecond_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 require 'time'
 
 class GigasecondCase < OpenStruct

--- a/lib/grains_cases.rb
+++ b/lib/grains_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class GrainsCase < OpenStruct
   def test_name
     'test_%s' % description.downcase.tr_s(' ', '_')

--- a/lib/hamming_cases.rb
+++ b/lib/hamming_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class HammingCase < OpenStruct
   def name
     'test_%s' % description.gsub(/[ -]/, '_')

--- a/lib/hello_world_cases.rb
+++ b/lib/hello_world_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class HelloWorldCase < OpenStruct
   def test_name
     'test_%s' % description.gsub(/[ -]/, '_')

--- a/lib/isogram_cases.rb
+++ b/lib/isogram_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class IsogramCase < OpenStruct
 
   def name

--- a/lib/largest_series_product_cases.rb
+++ b/lib/largest_series_product_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class LargestSeriesProductCase < OpenStruct
   def name
     'test_%s' % description.tr('()', '').tr(' -', '_').downcase

--- a/lib/leap_cases.rb
+++ b/lib/leap_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class LeapCase < OpenStruct
   def name
     'test_%s' % description.downcase.gsub(/[ -]/, '_')

--- a/lib/nth_prime_cases.rb
+++ b/lib/nth_prime_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class NthPrimeCase < OpenStruct
   def name
     'test_%s' % description.downcase.gsub(/[ -]/, '_')

--- a/lib/pangram_cases.rb
+++ b/lib/pangram_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class PangramCase < OpenStruct
   def name
     'test_%s' % description.downcase.tr_s(" -'", '_').sub(/_$/, '')

--- a/lib/queen_attack_cases.rb
+++ b/lib/queen_attack_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class QueenCase < OpenStruct
   def test_name
     "test_#{description.gsub(/[ ]/, '_')}"

--- a/lib/raindrops_cases.rb
+++ b/lib/raindrops_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class RaindropsCase < OpenStruct
   def name
     'test_%s' % number

--- a/lib/rna_transcription_cases.rb
+++ b/lib/rna_transcription_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class RnaTranscriptionCase < OpenStruct
   def test_name
     'test_%s' % description.gsub(/[ -]/, '_')

--- a/lib/roman_numerals_cases.rb
+++ b/lib/roman_numerals_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class RomanNumeralsCase < OpenStruct
   def name
     'test_%s' % number.to_s

--- a/lib/run_length_encoding_cases.rb
+++ b/lib/run_length_encoding_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class RunLengthEncodingCase < OpenStruct
   def name
     'test_%s' % cleaned_description

--- a/lib/sieve_cases.rb
+++ b/lib/sieve_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class SieveCase < OpenStruct
   OPEN_ARRAY = "[\n\s\s\s\s\s\s".freeze
   CLOSE_ARRAY = "\n\s\s\s\s]".freeze

--- a/lib/tournament_cases.rb
+++ b/lib/tournament_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class TournamentCase < OpenStruct
   def test_name
     "test_#{description.tr(' ', '_').tr('()', '')}"

--- a/lib/transpose_cases.rb
+++ b/lib/transpose_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class TransposeCase < OpenStruct
   def test_name
     "test_#{description.tr(' ', '_')}"

--- a/lib/triangle_cases.rb
+++ b/lib/triangle_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class TriangleCase < OpenStruct
   def test_name
     initial = description.downcase

--- a/lib/two_bucket_cases.rb
+++ b/lib/two_bucket_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class TwoBucketCase < OpenStruct
   def test_name
     "test_bucket_one_#{bucket_one}_bucket_two_"\

--- a/lib/word_count_cases.rb
+++ b/lib/word_count_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class WordCountCase < OpenStruct
   def name
     'test_%s' % description.tr(' ', '_')

--- a/lib/wordy_cases.rb
+++ b/lib/wordy_cases.rb
@@ -1,3 +1,5 @@
+require 'exercise_cases'
+
 class WordyCase < OpenStruct
   def test_name
     'test_%s' % description.downcase.tr(' ', '_')

--- a/test/fixtures/xruby/exercises/alpha/example.tt
+++ b/test/fixtures/xruby/exercises/alpha/example.tt
@@ -4,7 +4,7 @@
 require 'minitest/autorun'
 require_relative 'alpha'
 
-# Common test data version: <%= sha1 %>
+# Common test data version: <%= abbreviated_commit_hash %>
 class AlphaTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skip %>

--- a/test/fixtures/xruby/exercises/alpha/example.tt
+++ b/test/fixtures/xruby/exercises/alpha/example.tt
@@ -15,6 +15,6 @@ class AlphaTest < Minitest::Test<% test_cases.each do |test_case| %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>
   def test_bookkeeping
     skip
-    assert_equal <%= version.next %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -2,26 +2,26 @@ require_relative '../test_helper'
 
 module Generator
   class TestCasesValuesTest < Minitest::Test
-    def test_sha1
-      expected_sha1 = '1234567'
-      subject = TemplateValues.new(sha1: expected_sha1, version: nil, test_cases: nil)
-      assert_equal expected_sha1, subject.sha1
+    def test_abbreviated_commit_hash
+      expected_abbreviated_commit_hash = '1234567'
+      subject = TemplateValues.new(abbreviated_commit_hash: expected_abbreviated_commit_hash, version: nil, test_cases: nil)
+      assert_equal expected_abbreviated_commit_hash, subject.abbreviated_commit_hash
     end
 
     def test_version
       expected_version = '1234567'
-      subject = TemplateValues.new(version: expected_version, sha1: nil, test_cases: nil)
+      subject = TemplateValues.new(version: expected_version, abbreviated_commit_hash: nil, test_cases: nil)
       assert_equal expected_version, subject.version
     end
 
     def test_test_cases
       expected_test_cases = 'should be TemplateValues class'
-      subject = TemplateValues.new(test_cases: expected_test_cases, sha1: nil, version: nil)
+      subject = TemplateValues.new(test_cases: expected_test_cases, abbreviated_commit_hash: nil, version: nil)
       assert_equal expected_test_cases, subject.test_cases
     end
 
     def test_get_binding
-      subject = TemplateValues.new(sha1: nil, version: nil, test_cases: nil)
+      subject = TemplateValues.new(abbreviated_commit_hash: nil, version: nil, test_cases: nil)
       assert_instance_of Binding, subject.get_binding
     end
   end


### PR DESCRIPTION
This patch addresses the outstanding TODOs in the recent generator refactor.

Changes all `exercise.tt` files:
* Remove compensation for version increment in templates.
* Rename `sha1` to `abbreviated_commit_hash`
* Standardise common test data reference comment.

Changes all `lib/*_cases.rb` files:
* move the exercise cases `require`s out of the generator.

I was initially planning on doing this as 3 Pull Requests, but the default git settings weren't quite clever enough to work out how to merge the independent changes without conflicts so I've applied them all in one PR. The individual commits show the independent steps.
