### PR TITLE
Rubocop: Enable space after comma cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1559,7 +1559,7 @@ Style/SpaceAfterColon:
 Style/SpaceAfterComma:
   Description: Use spaces after commas.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: false
+  Enabled: true
 
 # Supports --auto-correct
 Style/SpaceAfterControlKeyword:

--- a/bin/enable-executable
+++ b/bin/enable-executable
@@ -5,7 +5,7 @@ require 'fileutils'
 puts 'Ensuring test files are executable.'
 
 # Assume that this file lives in #{base}/bin
-base = File.join(__dir__,'..')
+base = File.join(__dir__, '..')
 files = Dir.glob("#{base}/**/*test.rb") + Dir.glob("#{base}/bin/*")
 
 files.each do |file|

--- a/bin/executable-tests-check
+++ b/bin/executable-tests-check
@@ -2,7 +2,7 @@
 require 'minitest/autorun'
 
 # Assume that this file lives in #{base}/bin
-base = File.join(__dir__,'..')
+base = File.join(__dir__, '..')
 files = Dir.glob("#{base}/exercises/**/*test.rb") + Dir.glob("#{base}/bin/*")
 
 files.each do |file|

--- a/exercises/connect/example.rb
+++ b/exercises/connect/example.rb
@@ -33,7 +33,7 @@ class Board
 
   def start_of(winner)
     case winner
-    when BLACK then (0...@height).map { |y| Position.new(0,y) }
+    when BLACK then (0...@height).map { |y| Position.new(0, y) }
     when WHITE then (0...@width).map { |x| Position.new(x, 0) }
     end
   end

--- a/exercises/diamond/example.rb
+++ b/exercises/diamond/example.rb
@@ -10,7 +10,7 @@ class Diamond
     middle = total_lines/2
     letter_char_code = 65
     (0..total_lines - 1).each do |i|
-      line = Array.new(total_lines," ")                      # creates a line in each loop
+      line = Array.new(total_lines, " ")                      # creates a line in each loop
       if i == 0 || i == total_lines - 1                      # placing the letter A in the beginning and end
         line[middle] = "A"
       else

--- a/exercises/simple-linked-list/simple_linked_list_test.rb
+++ b/exercises/simple-linked-list/simple_linked_list_test.rb
@@ -78,26 +78,26 @@ class LinkedListTest < Minitest::Test
     second = Element.new(2)
     third = Element.new(3)
     list.push(first).push(second).push(third)
-    assert_equal [3,2,1], list.to_a
+    assert_equal [3, 2, 1], list.to_a
   end
 
   def test_list_create_from_array
     skip
-    array = [1,2,3]
+    array = [1, 2, 3]
     list = SimpleLinkedList.new(array)
-    assert_equal [3,2,1], list.to_a
+    assert_equal [3, 2, 1], list.to_a
   end
 
   def test_list_created_from_array_still_made_up_of_elements
     skip
-    array = [1,2,3]
+    array = [1, 2, 3]
     list = SimpleLinkedList.new(array)
     assert_equal Element, list.pop.class
   end
 
   def test_list_from_array_still_acts_as_lifo
     skip
-    array = [1,2,3]
+    array = [1, 2, 3]
     list = SimpleLinkedList.new(array)
     element = list.pop
     assert_equal 3, element.datum
@@ -111,7 +111,7 @@ class LinkedListTest < Minitest::Test
     list = SimpleLinkedList.new
     list.push(first).push(second).push(third)
 
-    assert_equal [1,2,3], list.reverse!.to_a
+    assert_equal [1, 2, 3], list.reverse!.to_a
   end
 
   def test_list_in_place_reverse_are_the_same_elements

--- a/lib/all_your_base_cases.rb
+++ b/lib/all_your_base_cases.rb
@@ -95,7 +95,7 @@ class AllYourBaseCase::PreProcessor
     end
 
     def handle_special_cases
-      [4,2] if row['input_digits'] == [0, 6, 0]
+      [4, 2] if row['input_digits'] == [0, 6, 0]
     end
   end
 end

--- a/lib/alphametics_cases.rb
+++ b/lib/alphametics_cases.rb
@@ -20,7 +20,7 @@ class AlphameticsCase < OpenStruct
       "input = %s\n" % input,
       "expected = %s\n" % expect,
       "assert_equal expected, Alphametics.solve(input)"
-    indent(body,4)
+    indent(body, 4)
   end
 
   def runtime_comment
@@ -30,7 +30,7 @@ class AlphameticsCase < OpenStruct
         "# The obvious algorithm can take a long time to solve this puzzle,\n",
         "# but an optimised solution can solve it fairly quickly.\n",
         "# (It's OK to submit your solution without getting this test to pass.)\n"
-      indent(comments,2)
+      indent(comments, 2)
     end
   end
 
@@ -41,7 +41,7 @@ class AlphameticsCase < OpenStruct
   end
 
   def expected_values
-    "{ #{indent(expected_values_as_lines,17)} }"
+    "{ #{indent(expected_values_as_lines, 17)} }"
   end
 
   def expected_values_as_lines
@@ -50,7 +50,7 @@ class AlphameticsCase < OpenStruct
   end
 
   def expected_values_as_strings
-    expected.sort.map { |(key,value)| "'#{key}' => #{value}" }
+    expected.sort.map { |(key, value)| "'#{key}' => #{value}" }
   end
 
   def add_trailing_comma_and_newline(lines)

--- a/lib/generator/files.rb
+++ b/lib/generator/files.rb
@@ -4,7 +4,7 @@ module Generator
   module Files
     class Readable
       attr_reader :filename, :repository_root
-      def initialize(filename:,repository_root: nil)
+      def initialize(filename:, repository_root: nil)
         @filename = filename
         @repository_root = repository_root
       end

--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -11,7 +11,7 @@ module Generator
       end
 
       def filename(exercise_name)
-        "#{exercise_name.tr('-','_')}_cases"
+        "#{exercise_name.tr('-', '_')}_cases"
       end
 
       def proc_name(exercise_name)
@@ -19,7 +19,7 @@ module Generator
       end
 
       def exercise_name(filename)
-        %r{([^/]*)_cases\.rb$}.match(filename).captures[0].tr('_','-')
+        %r{([^/]*)_cases\.rb$}.match(filename).captures[0].tr('_', '-')
       end
     end
 
@@ -71,7 +71,7 @@ module Generator
     end
 
     class MinitestTestsFile < Writable
-      def generate(template:,values:)
+      def generate(template:, values:)
         content = ERB.new(template, nil, '<>').result values.get_binding
         save(content)
       end

--- a/lib/grains_cases.rb
+++ b/lib/grains_cases.rb
@@ -14,7 +14,7 @@ class GrainsCase < OpenStruct
   private
 
   def underscore_format(number)
-    number.to_s.reverse.gsub(/...(?=.)/,'\&_').reverse
+    number.to_s.reverse.gsub(/...(?=.)/, '\&_').reverse
   end
 end
 

--- a/lib/isogram_cases.rb
+++ b/lib/isogram_cases.rb
@@ -1,7 +1,7 @@
 class IsogramCase < OpenStruct
 
   def name
-    format('test_%s', description.downcase.gsub(/[ -]/,'_'))
+    format('test_%s', description.downcase.gsub(/[ -]/, '_'))
   end
 
   def assertion

--- a/lib/pangram_cases.rb
+++ b/lib/pangram_cases.rb
@@ -1,6 +1,6 @@
 class PangramCase < OpenStruct
   def name
-    'test_%s' % description.downcase.tr_s(" -'", '_').sub(/_$/,'')
+    'test_%s' % description.downcase.tr_s(" -'", '_').sub(/_$/, '')
   end
 
   def workload

--- a/test/fixtures/xruby/lib/alpha_cases.rb
+++ b/test/fixtures/xruby/lib/alpha_cases.rb
@@ -1,7 +1,7 @@
 class AlphaCase < OpenStruct
 
   def name
-    format('test_%s', description.downcase.gsub(/[ -]/,'_'))
+    format('test_%s', description.downcase.gsub(/[ -]/, '_'))
   end
 
   def assertion

--- a/test/generator/command_line_test.rb
+++ b/test/generator/command_line_test.rb
@@ -16,7 +16,7 @@ module Generator
 
     def test_invalid_metadata_repository_outputs_message_to_stderr
       paths = Paths.new(metadata: 'test/fixtures/nonexistent', track: nil)
-      expected_stderr = <<-MESSAGE.gsub(/^ {6}/,'')
+      expected_stderr = <<-MESSAGE.gsub(/^ {6}/, '')
       'x-common' repository not found.
       Try running the command:
         git clone https://github.com/exercism/x-common.git "test/fixtures/nonexistent"

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -21,7 +21,7 @@ module Generator
     end
 
     def test_get_binding
-      subject = TemplateValues.new(sha1: nil,version: nil, test_cases: nil)
+      subject = TemplateValues.new(sha1: nil, version: nil, test_cases: nil)
       assert_instance_of Binding, subject.get_binding
     end
   end


### PR DESCRIPTION
@kotp flagged a missing space after comma in a review: https://github.com/exercism/xruby/pull/540#pullrequestreview-16715930

This patch enables the Style/SpaceAfterComma cop so that this can be automatically detected and fixed by Rubocop.