### PR TITLE
Standardize hello-world generator.

### DIFF
--- a/exercises/hello-world/example.tt
+++ b/exercises/hello-world/example.tt
@@ -13,13 +13,14 @@ rescue LoadError => e
 end
 
 # Common test data version: <%= abbreviated_commit_hash %>
-class HelloWorldTest < Minitest::Test<% test_cases.each do |test_case| %>
-  def <%= test_case.test_name %><% if test_case.skipped? %>
-    skip<% end %>
+class HelloWorldTest < Minitest::Test
+<% test_cases.each do |test_case| %>
+  def <%= test_case.test_name %>
     <%= test_case.skipped %>
     <%= test_case.workload %>
   end
-<% end %>end
+<% end %>
+end
 
 __END__
 

--- a/exercises/hello-world/example.tt
+++ b/exercises/hello-world/example.tt
@@ -16,6 +16,7 @@ end
 class HelloWorldTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %><% if test_case.skipped? %>
     skip<% end %>
+    <%= test_case.skipped %>
     <%= test_case.workload %>
   end
 <% end %>end

--- a/exercises/hello-world/example.tt
+++ b/exercises/hello-world/example.tt
@@ -16,7 +16,7 @@ end
 class HelloWorldTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %><% if test_case.skipped? %>
     skip<% end %>
-    assert_equal '<%= test_case.expected %>', <%= test_case.do %>
+    <%= test_case.workload %>
   end
 <% end %>end
 

--- a/exercises/hello-world/hello_world_test.rb
+++ b/exercises/hello-world/hello_world_test.rb
@@ -15,6 +15,7 @@ end
 # Common test data version: 4b9ae53
 class HelloWorldTest < Minitest::Test
   def test_hello
+    # skip
     assert_equal 'Hello, World!', HelloWorld.hello
   end
 end

--- a/exercises/hello-world/hello_world_test.rb
+++ b/exercises/hello-world/hello_world_test.rb
@@ -16,7 +16,7 @@ end
 class HelloWorldTest < Minitest::Test
   def test_hello
     # skip
-    assert_equal 'Hello, World!', HelloWorld.hello
+    assert_equal "Hello, World!", HelloWorld.hello
   end
 end
 

--- a/lib/hello_world_cases.rb
+++ b/lib/hello_world_cases.rb
@@ -9,6 +9,10 @@ class HelloWorldCase < OpenStruct
     "assert_equal '#{expected}', #{self.do}"
   end
 
+  def skipped
+    index.zero? ? '# skip' : 'skip'
+  end
+
   def do
     'HelloWorld.hello'
   end

--- a/lib/hello_world_cases.rb
+++ b/lib/hello_world_cases.rb
@@ -5,6 +5,10 @@ class HelloWorldCase < OpenStruct
     'test_%s' % property.gsub(/[ -]/, '_')
   end
 
+  def workload
+    "assert_equal '#{expected}', #{self.do}"
+  end
+
   def do
     'HelloWorld.hello'
   end

--- a/lib/hello_world_cases.rb
+++ b/lib/hello_world_cases.rb
@@ -6,19 +6,11 @@ class HelloWorldCase < OpenStruct
   end
 
   def workload
-    "assert_equal '#{expected}', #{self.do}"
+    "assert_equal '#{expected}', HelloWorld.hello"
   end
 
   def skipped
     index.zero? ? '# skip' : 'skip'
-  end
-
-  def do
-    'HelloWorld.hello'
-  end
-
-  def skipped?
-    index > 0
   end
 end
 

--- a/lib/hello_world_cases.rb
+++ b/lib/hello_world_cases.rb
@@ -6,7 +6,7 @@ class HelloWorldCase < OpenStruct
   end
 
   def workload
-    "assert_equal '#{expected}', HelloWorld.hello"
+    "assert_equal #{expected.inspect}, HelloWorld.hello"
   end
 
   def skipped


### PR DESCRIPTION
Update the hello-world generator to use the standard generator method names.

## Description
Use the standard `workload` and `skipped` methods rather than the more ambiguous and template dependent `do` and `skipped?` methods.

## How Has This Been Tested?
Regenerated `hello-world_test.rb` which was almost identical to the original version.
### (Minor) Differences
* Change from sigle quotes to double quotes due to use of `inspect`
* Addition of commented out `#skip` call which now matches other generated tests.

