### PR TITLE
Rename 'work_load' to 'workload'

### DIFF
--- a/exercises/anagram/example.tt
+++ b/exercises/anagram/example.tt
@@ -7,7 +7,7 @@ require_relative 'anagram'
 class AnagramTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>
-    <%= test_case.work_load %>
+    <%= test_case.workload %>
   end
 <% end %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>

--- a/exercises/bowling/example.tt
+++ b/exercises/bowling/example.tt
@@ -16,7 +16,7 @@ class BowlingTest < Minitest::Test
 <% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>
-    <%= test_case.work_load %>
+    <%= test_case.workload %>
   end
 
 <% end %>

--- a/exercises/hamming/example.tt
+++ b/exercises/hamming/example.tt
@@ -7,8 +7,8 @@ require_relative 'hamming'
 class HammingTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %><% if test_case.raises_error? %>
-    assert_raises(ArgumentError) { <%= test_case.work_load %> }<% else %>
-    assert_equal <%= test_case.expected %>, <%= test_case.work_load %><% end %>
+    assert_raises(ArgumentError) { <%= test_case.workload %> }<% else %>
+    assert_equal <%= test_case.expected %>, <%= test_case.workload %><% end %>
   end
 <% end %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>

--- a/exercises/rna-transcription/example.tt
+++ b/exercises/rna-transcription/example.tt
@@ -7,7 +7,7 @@ require_relative 'rna_transcription'
 class ComplementTest < Minitest::Test<% test_cases.each do |test_case| %>
   def <%= test_case.test_name %>
     <%= test_case.skipped %>
-    assert_equal '<%= test_case.expected %>', <%= test_case.work_load %>
+    assert_equal '<%= test_case.expected %>', <%= test_case.workload %>
   end
 <% end %>
 <%= IO.read(XRUBY_LIB + '/bookkeeping.md') %>

--- a/lib/anagram_cases.rb
+++ b/lib/anagram_cases.rb
@@ -5,7 +5,7 @@ class AnagramCase < OpenStruct
     'test_%s' % description.gsub(/[ -]/, '_')
   end
 
-  def work_load
+  def workload
     indent_lines([show_comment, detector, anagram, assert].compact)
   end
 

--- a/lib/binary_cases.rb
+++ b/lib/binary_cases.rb
@@ -16,14 +16,14 @@ class BinaryCase < OpenStruct
   private
 
   def error_assertion
-    "assert_raises(ArgumentError) { #{work_load} }"
+    "assert_raises(ArgumentError) { #{workload} }"
   end
 
   def equality_assertion
-    "assert_equal #{expected}, #{work_load}"
+    "assert_equal #{expected}, #{workload}"
   end
 
-  def work_load
+  def workload
     "Binary.to_decimal('#{binary}')"
   end
 

--- a/lib/bowling_cases.rb
+++ b/lib/bowling_cases.rb
@@ -9,7 +9,7 @@ class BowlingCase < OpenStruct
     index.zero? ? '# skip' : 'skip'
   end
 
-  def work_load
+  def workload
     indent_lines(assert)
   end
 

--- a/lib/hamming_cases.rb
+++ b/lib/hamming_cases.rb
@@ -5,7 +5,7 @@ class HammingCase < OpenStruct
     'test_%s' % description.gsub(/[ -]/, '_')
   end
 
-  def work_load
+  def workload
     "Hamming.compute('#{strand1}', '#{strand2}')"
   end
 

--- a/lib/rna_transcription_cases.rb
+++ b/lib/rna_transcription_cases.rb
@@ -5,7 +5,7 @@ class RnaTranscriptionCase < OpenStruct
     'test_%s' % description.gsub(/[ -]/, '_')
   end
 
-  def work_load
+  def workload
     "Complement.of_dna('#{dna}')"
   end
 


### PR DESCRIPTION
We have standardized on `workload` for the method name that generates the body of a test.

`work_load` was used a few times prior to the standardization.

This PR updates these old usages to help avoid confusion.
