### PR TITLE
Linked list: add tests for emptied list.

### DIFF
--- a/exercises/linked-list/linked_list_test.rb
+++ b/exercises/linked-list/linked_list_test.rb
@@ -53,4 +53,20 @@ class DequeTest < Minitest::Test
     assert_equal 50, deque.pop
     assert_equal 30, deque.shift
   end
+
+  def test_pop_to_empty
+    deque = Deque.new
+    deque.push(10)
+    assert_equal 10, deque.pop
+    deque.push(20)
+    assert_equal 20, deque.shift
+  end
+
+  def test_shift_to_empty
+    deque = Deque.new
+    deque.unshift(10)
+    assert_equal 10, deque.shift
+    deque.unshift(20)
+    assert_equal 20, deque.pop
+  end
 end


### PR DESCRIPTION
Adds tests to test if the opposite end of the Deque is nulled correctly when popping/shifting leaves the list empty.

---

The tests for the [Linked List exercise](https://github.com/exercism/xruby/tree/master/exercises/linked-list) don't yet test if, when popping or shifting should leave the list empty, the reverse end of the list is cleared/nulled correctly. When the list is empty, both the head and the tail ends should be empty/null.

Forgetting to do that is an easy mistake to make when implementing a doubly linked list, and the current test suite doesn't cover that yet.

This PR adds the tests for that, without the need to define the behaviour for error conditions (`pop` or `shift` on an empty list).

---

Closes #562.