### PR TITLE
Documentation: Readme - Add workload philosophy section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ for the default template for everything except `workload`.
 `workload` generates the code for the body of a test, including the assertion
 and any setup required. The base class provides a variety of assertion and
 helper methods. Beyond that, you can implement any helper methods that you need
-as private methods in your derived class.
+as private methods in your derived class. See below for more information about [the intention of workload](#workload-philosophy)
 
 Below this class, implement a small loop that will generate all the test cases by reading the
 `canonical-data.json` file, and looping through the test cases.
@@ -218,6 +218,23 @@ class ProblemNameTest < Minitest::Test
   end
 end
 ```
+### Workload philosophy.
+
+Within the test workload we want to prioritize educational value over expert comprehension and want to make sure that things are clear to people who may not be familiar with Minitest and even Ruby. 
+
+Therefore a multi line workload is preferred. 
+An example from `anagram`:
+```ruby
+detector = Anagram.new('allergy')
+anagrams = detector.match(["gallery", "ballerina", "regally", "clergy", "largely", "leading"])
+expected = ["gallery", "largely", "regally"]
+assert_equal expected, anagrams.sort
+```
+
+This provides the information the student needs to derive the code to pass the test in a clear and consistent manner.
+Intention revealing variable names are used to illustrate the purpose of the individual elements of what could otherwise be a one line assertion. The values used in `detector`,`anagrams` and `expected` will all vary by test.  
+
+
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -220,20 +220,20 @@ end
 ```
 ### Workload philosophy.
 
-Within the test workload we want to prioritize educational value over expert comprehension and want to make sure that things are clear to people who may not be familiar with Minitest and even Ruby. 
+Prioritize educational value over expert comprehension and make sure that
+things are clear to people who may not be familiar with Minitest and even Ruby. 
 
-Therefore a multi line workload is preferred. 
-An example from `anagram`:
+Provide the information the student needs to derive the code to pass the test
+in a clear and consistent manner. Illustrate the purpose of the individual
+elements of the assertion by using meaningful variable names.
+
+Example output from the `workload` method:
 ```ruby
 detector = Anagram.new('allergy')
 anagrams = detector.match(["gallery", "ballerina", "regally", "clergy", "largely", "leading"])
 expected = ["gallery", "largely", "regally"]
 assert_equal expected, anagrams.sort
 ```
-
-This provides the information the student needs to derive the code to pass the test in a clear and consistent manner.
-Intention revealing variable names are used to illustrate the purpose of the individual elements of what could otherwise be a one line assertion. The values used in `detector`,`anagrams` and `expected` will all vary by test.  
-
 
 
 ## Pull Requests


### PR DESCRIPTION
Add a workload philosophy section to `Readme.md`

The Workload philosophy section gives some information about why an
educational workload layout is preferable to a concise one liner.

Inspired by: https://github.com/exercism/xruby/pull/567#pullrequestreview-34227224
