### PR TITLE
Fix "exercise_cases" require path

### DIFF
--- a/lib/acronym_cases.rb
+++ b/lib/acronym_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class AcronymCase < ExerciseCase
 

--- a/lib/all_your_base_cases.rb
+++ b/lib/all_your_base_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class AllYourBaseCase < ExerciseCase
 

--- a/lib/alphametics_cases.rb
+++ b/lib/alphametics_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class AlphameticsCase < ExerciseCase
   def workload

--- a/lib/anagram_cases.rb
+++ b/lib/anagram_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class AnagramCase < ExerciseCase
 

--- a/lib/beer_song_cases.rb
+++ b/lib/beer_song_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class BeerSongCase < ExerciseCase
 

--- a/lib/binary_cases.rb
+++ b/lib/binary_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class BinaryCase < ExerciseCase
 

--- a/lib/bowling_cases.rb
+++ b/lib/bowling_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class BowlingCase < ExerciseCase
 

--- a/lib/bracket_push_cases.rb
+++ b/lib/bracket_push_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class BracketPushCase < ExerciseCase
 

--- a/lib/clock_cases.rb
+++ b/lib/clock_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class ClockCase < ExerciseCase
   def name

--- a/lib/connect_cases.rb
+++ b/lib/connect_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class ConnectCase < ExerciseCase
 

--- a/lib/custom_set_cases.rb
+++ b/lib/custom_set_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class CustomSetCase < ExerciseCase
 

--- a/lib/difference_of_squares_cases.rb
+++ b/lib/difference_of_squares_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class DifferenceOfSquaresCase < ExerciseCase
 

--- a/lib/dominoes_cases.rb
+++ b/lib/dominoes_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class DominoesCase < ExerciseCase
   def name

--- a/lib/exercise_cases.rb
+++ b/lib/exercise_cases.rb
@@ -1,2 +1,0 @@
-require 'ostruct'
-require 'json'

--- a/lib/gigasecond_cases.rb
+++ b/lib/gigasecond_cases.rb
@@ -1,3 +1,4 @@
+require 'generator/exercise_cases'
 require 'time'
 
 class GigasecondCase < ExerciseCase

--- a/lib/grains_cases.rb
+++ b/lib/grains_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class GrainsCase < ExerciseCase
 

--- a/lib/hamming_cases.rb
+++ b/lib/hamming_cases.rb
@@ -1,3 +1,5 @@
+require 'generator/exercise_cases'
+
 class HammingCase < ExerciseCase
   def workload
     if raises_error?

--- a/lib/hello_world_cases.rb
+++ b/lib/hello_world_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class HelloWorldCase < ExerciseCase
 

--- a/lib/isogram_cases.rb
+++ b/lib/isogram_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class IsogramCase < ExerciseCase
 

--- a/lib/largest_series_product_cases.rb
+++ b/lib/largest_series_product_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class LargestSeriesProductCase < ExerciseCase
 

--- a/lib/leap_cases.rb
+++ b/lib/leap_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class LeapCase < ExerciseCase
 

--- a/lib/luhn_cases.rb
+++ b/lib/luhn_cases.rb
@@ -1,3 +1,5 @@
+require 'generator/exercise_cases'
+
 class LuhnCase < ExerciseCase
   def workload
     "#{assert} Luhn.valid?(#{input.inspect})"

--- a/lib/nth_prime_cases.rb
+++ b/lib/nth_prime_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class NthPrimeCase < ExerciseCase
 

--- a/lib/ocr_numbers_cases.rb
+++ b/lib/ocr_numbers_cases.rb
@@ -1,3 +1,5 @@
+require 'generator/exercise_cases'
+
 class OcrNumbersCase < ExerciseCase
   def workload
     if raises_error?

--- a/lib/pangram_cases.rb
+++ b/lib/pangram_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class PangramCase < ExerciseCase
   def workload

--- a/lib/pig_latin_cases.rb
+++ b/lib/pig_latin_cases.rb
@@ -1,3 +1,5 @@
+require 'generator/exercise_cases'
+
 class PigLatinCase < ExerciseCase
   def workload
     assert_equal { "PigLatin.translate(#{input.inspect})" }

--- a/lib/queen_attack_cases.rb
+++ b/lib/queen_attack_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class QueenAttackCase < ExerciseCase
 

--- a/lib/raindrops_cases.rb
+++ b/lib/raindrops_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class RaindropsCase < ExerciseCase
 

--- a/lib/rna_transcription_cases.rb
+++ b/lib/rna_transcription_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class RnaTranscriptionCase < ExerciseCase
 

--- a/lib/roman_numerals_cases.rb
+++ b/lib/roman_numerals_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class RomanNumeralsCase < ExerciseCase
   def name

--- a/lib/run_length_encoding_cases.rb
+++ b/lib/run_length_encoding_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class RunLengthEncodingCase < ExerciseCase
 

--- a/lib/say_cases.rb
+++ b/lib/say_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class SayCase < ExerciseCase
 

--- a/lib/sieve_cases.rb
+++ b/lib/sieve_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class SieveCase < ExerciseCase
   OPEN_ARRAY = "[\n\s\s\s\s\s\s".freeze

--- a/lib/tournament_cases.rb
+++ b/lib/tournament_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class TournamentCase < ExerciseCase
 

--- a/lib/transpose_cases.rb
+++ b/lib/transpose_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class TransposeCase < ExerciseCase
 

--- a/lib/triangle_cases.rb
+++ b/lib/triangle_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class TriangleCase < ExerciseCase
   def name

--- a/lib/two_bucket_cases.rb
+++ b/lib/two_bucket_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class TwoBucketCase < ExerciseCase
   def name

--- a/lib/word_count_cases.rb
+++ b/lib/word_count_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class WordCountCase < ExerciseCase
 

--- a/lib/wordy_cases.rb
+++ b/lib/wordy_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class WordyCase < ExerciseCase
 

--- a/test/fixtures/xruby/lib/beta_cases.rb
+++ b/test/fixtures/xruby/lib/beta_cases.rb
@@ -1,4 +1,4 @@
-require 'exercise_cases'
+require 'generator/exercise_cases'
 
 class BetaCase < ExerciseCase
   def workload


### PR DESCRIPTION
Updates all `lib/*_cases.rb` files to use the correct `exercise_cases.rb` file which is in `lib/generator` and removes the other one from `lib`, which is no longer used.

I have also added the require line to the files that were missing it.

Generation works even without the `require`, due to `generator/exercise_cases.rb` being required by the generator, but it is a good idea to make explicit the dependency within *_cases.rb file.

This also fixes the bug that `exercise` appeared in the list of available generators even though there was no `exercise` problem or test case generator for it.
