### PR TITLE
Revert "extract template metadata into own class"

### DIFF
--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -1,29 +1,17 @@
-require 'forwardable'
-
 module Generator
   # Contains methods accessible to the ERB template
   class TemplateValues
-    attr_reader :metadata, :test_cases
-    extend Forwardable
-    def_delegators :@metadata, :abbreviated_commit_hash, :version, :exercise_name, :exercise_name_camel
+    attr_reader :abbreviated_commit_hash, :version, :exercise_name, :test_cases
 
-    def initialize(metadata:, test_cases:)
-      @metadata = metadata
+    def initialize(abbreviated_commit_hash:, version:, exercise_name:, test_cases:)
+      @abbreviated_commit_hash = abbreviated_commit_hash
+      @version = version
+      @exercise_name = exercise_name ? exercise_name.tr('-_', '_') : ''
       @test_cases = test_cases
     end
 
     def get_binding
       binding
-    end
-  end
-
-  class TemplateMetadata
-    attr_reader :abbreviated_commit_hash, :version, :exercise_name
-
-    def initialize(abbreviated_commit_hash:, version:, exercise_name:)
-      @abbreviated_commit_hash = abbreviated_commit_hash
-      @version = version
-      @exercise_name = exercise_name ? exercise_name.tr('-_', '_') : ''
     end
 
     def exercise_name_camel
@@ -34,11 +22,9 @@ module Generator
   module TemplateValuesFactory
     def template_values
       TemplateValues.new(
-        metadata: TemplateMetadata.new(
-          abbreviated_commit_hash: canonical_data.abbreviated_commit_hash,
-          version: version,
-          exercise_name: exercise_name
-        ),
+        abbreviated_commit_hash: canonical_data.abbreviated_commit_hash,
+        version: version,
+        exercise_name: exercise_name,
         test_cases: extract
       )
     end

--- a/lib/generator/test_template.erb
+++ b/lib/generator/test_template.erb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
-require_relative '<%= metadata.exercise_name %>'
+require_relative '<%= exercise_name %>'
 
-# Common test data version: <%= metadata.abbreviated_commit_hash %>
-class <%= metadata.exercise_name_camel %>Test < Minitest::Test
+# Common test data version: <%= abbreviated_commit_hash %>
+class <%= exercise_name_camel %>Test < Minitest::Test
 <% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %>
@@ -16,6 +16,6 @@ class <%= metadata.exercise_name_camel %>Test < Minitest::Test
 
   def test_bookkeeping
     skip
-    assert_equal <%= metadata.version %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/test/fixtures/xruby/lib/generator/test_template.erb
+++ b/test/fixtures/xruby/lib/generator/test_template.erb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
-require_relative '<%= metadata.exercise_name %>'
+require_relative 'acronym'
 
-# Common test data version: <%= metadata.abbreviated_commit_hash %>
-class <%= metadata.exercise_name_camel %>Test < Minitest::Test
+# Common test data version: <%= abbreviated_commit_hash %>
+class AcronymTest < Minitest::Test
 <% test_cases.each do |test_case| %>
   def <%= test_case.name %>
     <%= test_case.skipped %>
@@ -16,6 +16,6 @@ class <%= metadata.exercise_name_camel %>Test < Minitest::Test
 
   def test_bookkeeping
     skip
-    assert_equal <%= metadata.version %>, BookKeeping::VERSION
+    assert_equal <%= version %>, BookKeeping::VERSION
   end
 end

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -1,54 +1,46 @@
 require_relative '../test_helper'
 
 module Generator
-  class TemplateValuesTest < Minitest::Test
-    def test_metadata
-      expected_metadata = TemplateMetadata.new(abbreviated_commit_hash: nil, version: nil, exercise_name: nil)
-      subject = TemplateValues.new(metadata: expected_metadata, test_cases: nil)
-      assert_equal expected_metadata, subject.metadata
-    end
-
-    def test_test_cases
-      expected_test_cases = 'should be TemplateValues class'
-      subject = TemplateValues.new(metadata: nil, test_cases: expected_test_cases)
-      assert_equal expected_test_cases, subject.test_cases
-    end
-
-    def test_get_binding
-      subject = TemplateValues.new(metadata: nil, test_cases: nil)
-      assert_instance_of Binding, subject.get_binding
-    end
-  end
-
-  class TemplateMetadataTest < Minitest::Test
+  class TestCasesValuesTest < Minitest::Test
     def setup
       @arguments = {
-        abbreviated_commit_hash: nil, version: nil, exercise_name: nil
+        abbreviated_commit_hash: nil, version: nil, exercise_name: nil, test_cases: nil
       }
     end
 
     def test_abbreviated_commit_hash
       expected_abbreviated_commit_hash = '1234567'
-      subject = TemplateMetadata.new(@arguments.merge(abbreviated_commit_hash: expected_abbreviated_commit_hash))
+      subject = TemplateValues.new(@arguments.merge(abbreviated_commit_hash: expected_abbreviated_commit_hash))
       assert_equal expected_abbreviated_commit_hash, subject.abbreviated_commit_hash
     end
 
     def test_version
       expected_version = '1234567'
-      subject = TemplateMetadata.new(@arguments.merge(version: expected_version))
+      subject = TemplateValues.new(@arguments.merge(version: expected_version))
       assert_equal expected_version, subject.version
     end
 
     def test_exercise_name
       expected_exercise_name = 'alpha_beta'
-      subject = TemplateMetadata.new(@arguments.merge(exercise_name: 'alpha-beta'))
+      subject = TemplateValues.new(@arguments.merge(exercise_name: 'alpha-beta'))
       assert_equal expected_exercise_name, subject.exercise_name
     end
 
     def test_exercise_name_camel
       expected_exercise_name_camel = 'AlphaBeta'
-      subject = TemplateMetadata.new(@arguments.merge(exercise_name: 'alpha-beta'))
+      subject = TemplateValues.new(@arguments.merge(exercise_name: 'alpha-beta'))
       assert_equal expected_exercise_name_camel, subject.exercise_name_camel
+    end
+
+    def test_test_cases
+      expected_test_cases = 'should be TemplateValues class'
+      subject = TemplateValues.new(@arguments.merge(test_cases: expected_test_cases))
+      assert_equal expected_test_cases, subject.test_cases
+    end
+
+    def test_get_binding
+      subject = TemplateValues.new(@arguments)
+      assert_instance_of Binding, subject.get_binding
     end
   end
 


### PR DESCRIPTION
This reverts commit e43b6f4560a737afba004676e6434375ec276384.

I'm not sure this is the right thing to be doing, removing it from master until we can work out if it is.