### PR TITLE
Add query for version of canonical data

### DIFF
--- a/lib/generator/files.rb
+++ b/lib/generator/files.rb
@@ -2,6 +2,10 @@ require 'pathname'
 
 module Generator
   module Files
+    def self.read(filename)
+      File.read(filename) if File.exist?(filename)
+    end
+
     class Readable
       attr_reader :filename, :repository_root
       def initialize(filename:, repository_root: nil)
@@ -10,7 +14,7 @@ module Generator
       end
 
       def to_s
-        File.read(filename) if File.exist?(filename)
+        Files.read(filename)
       end
 
       def abbreviated_commit_hash

--- a/lib/generator/files/metadata_files.rb
+++ b/lib/generator/files/metadata_files.rb
@@ -18,6 +18,7 @@ module Generator
 
     class CanonicalDataFile < Readable
       def version
+        JSON.parse(to_s)['version'] if to_s
       end
     end
   end

--- a/lib/generator/files/metadata_files.rb
+++ b/lib/generator/files/metadata_files.rb
@@ -17,6 +17,8 @@ module Generator
     end
 
     class CanonicalDataFile < Readable
+      def version
+      end
     end
   end
 end

--- a/test/generator/files/metadata_files_test.rb
+++ b/test/generator/files/metadata_files_test.rb
@@ -32,6 +32,11 @@ module Generator
         subject = CanonicalDataFile.new(filename: 'test/fixtures/metadata/exercises/complex/canonical-data.json')
         assert_equal "1.0.0", subject.version
       end
+
+      def test_version_not_present
+        subject = CanonicalDataFile.new(filename: 'test/fixtures/metadata/exercises/alpha/canonical-data.json')
+        assert_nil subject.version
+      end
     end
   end
 end

--- a/test/generator/files/metadata_files_test.rb
+++ b/test/generator/files/metadata_files_test.rb
@@ -27,6 +27,11 @@ module Generator
         subject = CanonicalDataFile.new(filename: 'nonexistant')
         assert_nil subject.version
       end
+
+      def test_version
+        subject = CanonicalDataFile.new(filename: 'test/fixtures/metadata/exercises/complex/canonical-data.json')
+        assert_equal "1.0.0", subject.version
+      end
     end
   end
 end

--- a/test/generator/files/metadata_files_test.rb
+++ b/test/generator/files/metadata_files_test.rb
@@ -7,17 +7,9 @@ module Generator
         track: 'test/fixtures/xruby'
       )
 
-      class TestMetadataFiles
-        def initialize
-          @paths = FixturePaths
-          @exercise_name = 'alpha'
-        end
-        attr_reader :paths, :exercise_name
-        include MetadataFiles
-      end
-
       def test_canonical_data
-        subject = TestMetadataFiles.new
+        subject = OpenStruct.new(paths: FixturePaths, exercise_name: 'unimportant')
+        subject.extend(MetadataFiles)
         assert_instance_of CanonicalDataFile, subject.canonical_data
       end
     end

--- a/test/generator/files/metadata_files_test.rb
+++ b/test/generator/files/metadata_files_test.rb
@@ -21,5 +21,12 @@ module Generator
         assert_instance_of CanonicalDataFile, subject.canonical_data
       end
     end
+
+    class CanonicalDataFileTest < Minitest::Test
+      def test_version_for_file_that_does_not_exist
+        subject = CanonicalDataFile.new(filename: 'nonexistant')
+        assert_nil subject.version
+      end
+    end
   end
 end

--- a/test/generator/files/metadata_files_test.rb
+++ b/test/generator/files/metadata_files_test.rb
@@ -34,8 +34,10 @@ module Generator
       end
 
       def test_version_not_present
-        subject = CanonicalDataFile.new(filename: 'test/fixtures/metadata/exercises/alpha/canonical-data.json')
-        assert_nil subject.version
+        subject = CanonicalDataFile.new(filename: 'no version key')
+        Files.stub(:read, '{ "json": true }' ) do
+          assert_nil subject.version
+        end
       end
     end
   end

--- a/test/generator/files/metadata_files_test.rb
+++ b/test/generator/files/metadata_files_test.rb
@@ -29,8 +29,10 @@ module Generator
       end
 
       def test_version
-        subject = CanonicalDataFile.new(filename: 'test/fixtures/metadata/exercises/complex/canonical-data.json')
-        assert_equal "1.0.0", subject.version
+        subject = CanonicalDataFile.new(filename: 'has version key')
+        Files.stub(:read, '{"version": "1.2.3"}' ) do
+          assert_equal "1.2.3", subject.version
+        end
       end
 
       def test_version_not_present

--- a/test/generator/files_test.rb
+++ b/test/generator/files_test.rb
@@ -2,6 +2,24 @@ require_relative '../test_helper'
 
 module Generator
   module Files
+
+    class ReadTest < Minitest::Test
+      def test_read_existing_file
+        expected = 'content unimportant'
+        File.stub(:exist?, true) do
+          File.stub(:read, expected ) do
+            assert_equal expected, Files.read('pretend/this/exists')
+          end
+        end
+      end
+
+      def test_read_non_existing_file
+        File.stub(:exist?, false) do
+          assert_nil Files.read('pretend/this/does/not/exist')
+        end
+      end
+    end
+
     class ReadableTest < Minitest::Test
       def test_abbreviated_commit_hash
         mock_git_command = Minitest::Mock.new.expect :call, nil, ['path/.git', 'subdir/file']


### PR DESCRIPTION
Add query for the version of the canonical-data for a problem. `CanonicalDataFile#version`

The version string comes from the 'version' key of `canonical-data.json` file. 
It is a requirement that all canonical-data files have this key.

Having this will enable future use of this value for test automatic version detection/updating.

This patch also includes a refactoring which extracts a `Generator::Files#read` method which is a wrapper around `File.read(filename) if File.exist?(filename)`
This makes it possible to easily stub file reads during testing to reduce reliance on fixture files as part of the unit testing process.


See also: 
https://github.com/exercism/x-common#test-data-format-canonical-datajson
https://github.com/exercism/x-common#test-data-versioning

