### PR TITLE
Revert "Simplify test for MetadataFiles#canonical_data"

### DIFF
--- a/test/generator/files/metadata_files_test.rb
+++ b/test/generator/files/metadata_files_test.rb
@@ -7,9 +7,17 @@ module Generator
         track: 'test/fixtures/xruby'
       )
 
+      class TestMetadataFiles
+        def initialize
+          @paths = FixturePaths
+          @exercise_name = 'alpha'
+        end
+        attr_reader :paths, :exercise_name
+        include MetadataFiles
+      end
+
       def test_canonical_data
-        subject = OpenStruct.new(paths: FixturePaths, exercise_name: 'unimportant')
-        subject.extend(MetadataFiles)
+        subject = TestMetadataFiles.new
         assert_instance_of CanonicalDataFile, subject.canonical_data
       end
     end


### PR DESCRIPTION
This reverts commit 4f572e8e4bd3913f530439fdf4d3bfcc144d9aa6.

This change worked on Ruby 2.2 but stopped working from ruby 2.3 due to
changes in the way OpenStruct works.

See also:

http://stackoverflow.com/questions/39278864/openstruct-issue-with-ruby-2-3-1
minimal example: https://gist.github.com/anonymous/162dd5466b23331e0e31b891ac61d337
