### PR TITLE
generators: Exercise cases helper methods

### DIFF
--- a/exercises/acronym/.meta/generator/acronym_cases.rb
+++ b/exercises/acronym/.meta/generator/acronym_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class AcronymCase < ExerciseCase
+class AcronymCase < Generator::ExerciseCase
 
   def workload
     assert_equal { "Acronym.abbreviate('#{phrase}')" }

--- a/exercises/all-your-base/.meta/generator/all_your_base_cases.rb
+++ b/exercises/all-your-base/.meta/generator/all_your_base_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class AllYourBaseCase < ExerciseCase
+class AllYourBaseCase < Generator::ExerciseCase
 
   def workload
     indent(4, (assignments + assertion).join("\n")) + "\n"

--- a/exercises/alphametics/.meta/generator/alphametics_cases.rb
+++ b/exercises/alphametics/.meta/generator/alphametics_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class AlphameticsCase < ExerciseCase
+class AlphameticsCase < Generator::ExerciseCase
   def workload
     body =
       "input = %s\n" % input,

--- a/exercises/anagram/.meta/generator/anagram_cases.rb
+++ b/exercises/anagram/.meta/generator/anagram_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class AnagramCase < ExerciseCase
+class AnagramCase < Generator::ExerciseCase
 
   def workload
     indent_lines([show_comment, detector, anagram, wanted, assert].compact)

--- a/exercises/beer-song/.meta/generator/beer_song_cases.rb
+++ b/exercises/beer-song/.meta/generator/beer_song_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class BeerSongCase < ExerciseCase
+class BeerSongCase < Generator::ExerciseCase
 
   def workload
     "assert_equal expected, #{beer_song}"

--- a/exercises/binary/.meta/generator/binary_cases.rb
+++ b/exercises/binary/.meta/generator/binary_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class BinaryCase < ExerciseCase
+class BinaryCase < Generator::ExerciseCase
 
   def workload
     raises_error? ? error_assertion : equality_assertion

--- a/exercises/bowling/.meta/generator/bowling_cases.rb
+++ b/exercises/bowling/.meta/generator/bowling_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class BowlingCase < ExerciseCase
+class BowlingCase < Generator::ExerciseCase
 
   def workload
     indent_lines(assert)

--- a/exercises/bracket-push/.meta/generator/bracket_push_cases.rb
+++ b/exercises/bracket-push/.meta/generator/bracket_push_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class BracketPushCase < ExerciseCase
+class BracketPushCase < Generator::ExerciseCase
 
   def workload
     long_input? ? split_test : simple_test

--- a/exercises/clock/.meta/generator/clock_cases.rb
+++ b/exercises/clock/.meta/generator/clock_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class ClockCase < ExerciseCase
+class ClockCase < Generator::ExerciseCase
   def name
     'test_%s' % description
                 .gsub(/[() -]/, '_')

--- a/exercises/connect/.meta/generator/connect_cases.rb
+++ b/exercises/connect/.meta/generator/connect_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class ConnectCase < ExerciseCase
+class ConnectCase < Generator::ExerciseCase
 
   def test_body
     [

--- a/exercises/custom-set/.meta/generator/custom_set_cases.rb
+++ b/exercises/custom-set/.meta/generator/custom_set_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class CustomSetCase < ExerciseCase
+class CustomSetCase < Generator::ExerciseCase
 
   def workload
     send property

--- a/exercises/difference-of-squares/.meta/generator/difference_of_squares_cases.rb
+++ b/exercises/difference-of-squares/.meta/generator/difference_of_squares_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class DifferenceOfSquaresCase < ExerciseCase
+class DifferenceOfSquaresCase < Generator::ExerciseCase
 
   def workload
     %Q(assert_equal #{expected_formatted}, Squares.new(#{number}).#{action})

--- a/exercises/dominoes/.meta/generator/dominoes_cases.rb
+++ b/exercises/dominoes/.meta/generator/dominoes_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class DominoesCase < ExerciseCase
+class DominoesCase < Generator::ExerciseCase
   def name
     'test_%s' % description.gsub("can't", 'can not').gsub(/[= -]+/, '_')
   end

--- a/exercises/etl/.meta/generator/etl_cases.rb
+++ b/exercises/etl/.meta/generator/etl_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class EtlCase < ExerciseCase
+class EtlCase < Generator::ExerciseCase
   def workload
     indent_lines([
       "old = {\n      #{format(input)}\n    }",

--- a/exercises/gigasecond/.meta/generator/gigasecond_cases.rb
+++ b/exercises/gigasecond/.meta/generator/gigasecond_cases.rb
@@ -1,7 +1,7 @@
 require 'generator/exercise_cases'
 require 'time'
 
-class GigasecondCase < ExerciseCase
+class GigasecondCase < Generator::ExerciseCase
   def workload
     %Q(assert_equal #{want}, Gigasecond.from(#{got}))
   end

--- a/exercises/grains/.meta/generator/grains_cases.rb
+++ b/exercises/grains/.meta/generator/grains_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class GrainsCase < ExerciseCase
+class GrainsCase < Generator::ExerciseCase
 
   def workload
     send("#{property}_workload")

--- a/exercises/hamming/.meta/generator/hamming_cases.rb
+++ b/exercises/hamming/.meta/generator/hamming_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class HammingCase < ExerciseCase
+class HammingCase < Generator::ExerciseCase
   def workload
     if raises_error?
       assert_raises(ArgumentError) { test_case }

--- a/exercises/hello-world/.meta/generator/hello_world_cases.rb
+++ b/exercises/hello-world/.meta/generator/hello_world_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class HelloWorldCase < ExerciseCase
+class HelloWorldCase < Generator::ExerciseCase
 
   def workload
     assert_equal { "HelloWorld.hello" }

--- a/exercises/isogram/.meta/generator/isogram_cases.rb
+++ b/exercises/isogram/.meta/generator/isogram_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class IsogramCase < ExerciseCase
+class IsogramCase < Generator::ExerciseCase
 
   def workload
     indent_lines(

--- a/exercises/largest-series-product/.meta/generator/largest_series_product_cases.rb
+++ b/exercises/largest-series-product/.meta/generator/largest_series_product_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class LargestSeriesProductCase < ExerciseCase
+class LargestSeriesProductCase < Generator::ExerciseCase
 
   def workload
     if raises_error?

--- a/exercises/leap/.meta/generator/leap_cases.rb
+++ b/exercises/leap/.meta/generator/leap_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class LeapCase < ExerciseCase
+class LeapCase < Generator::ExerciseCase
 
   def workload
     "#{assert} Year.leap?(#{input.inspect})"

--- a/exercises/luhn/.meta/generator/luhn_cases.rb
+++ b/exercises/luhn/.meta/generator/luhn_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class LuhnCase < ExerciseCase
+class LuhnCase < Generator::ExerciseCase
   def workload
     "#{assert} Luhn.valid?(#{input.inspect})"
   end

--- a/exercises/nth-prime/.meta/generator/nth_prime_cases.rb
+++ b/exercises/nth-prime/.meta/generator/nth_prime_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class NthPrimeCase < ExerciseCase
+class NthPrimeCase < Generator::ExerciseCase
 
   def workload
     if raises_error?

--- a/exercises/ocr-numbers/.meta/generator/ocr_numbers_cases.rb
+++ b/exercises/ocr-numbers/.meta/generator/ocr_numbers_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class OcrNumbersCase < ExerciseCase
+class OcrNumbersCase < Generator::ExerciseCase
   def workload
     if raises_error?
       assert_raises(ArgumentError) { test_case }

--- a/exercises/pangram/.meta/generator/pangram_cases.rb
+++ b/exercises/pangram/.meta/generator/pangram_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class PangramCase < ExerciseCase
+class PangramCase < Generator::ExerciseCase
   def workload
     [
     "phrase = '#{input}'",

--- a/exercises/pig-latin/.meta/generator/pig_latin_cases.rb
+++ b/exercises/pig-latin/.meta/generator/pig_latin_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class PigLatinCase < ExerciseCase
+class PigLatinCase < Generator::ExerciseCase
   def workload
     assert_equal { "PigLatin.translate(#{input.inspect})" }
   end

--- a/exercises/queen-attack/.meta/generator/queen_attack_cases.rb
+++ b/exercises/queen-attack/.meta/generator/queen_attack_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class QueenAttackCase < ExerciseCase
+class QueenAttackCase < Generator::ExerciseCase
 
   def workload
     property == 'create' ? create_workload : attack_workload

--- a/exercises/raindrops/.meta/generator/raindrops_cases.rb
+++ b/exercises/raindrops/.meta/generator/raindrops_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class RaindropsCase < ExerciseCase
+class RaindropsCase < Generator::ExerciseCase
 
   def workload
     assert_equal { "Raindrops.convert(#{number})" }

--- a/exercises/rna-transcription/.meta/generator/rna_transcription_cases.rb
+++ b/exercises/rna-transcription/.meta/generator/rna_transcription_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class RnaTranscriptionCase < ExerciseCase
+class RnaTranscriptionCase < Generator::ExerciseCase
 
   def workload
     "assert_equal '#{expected}', Complement.of_dna('#{dna}')"

--- a/exercises/roman-numerals/.meta/generator/roman_numerals_cases.rb
+++ b/exercises/roman-numerals/.meta/generator/roman_numerals_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class RomanNumeralsCase < ExerciseCase
+class RomanNumeralsCase < Generator::ExerciseCase
   def name
     'test_%s' % number.to_s
   end

--- a/exercises/run-length-encoding/.meta/generator/run_length_encoding_cases.rb
+++ b/exercises/run-length-encoding/.meta/generator/run_length_encoding_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class RunLengthEncodingCase < ExerciseCase
+class RunLengthEncodingCase < Generator::ExerciseCase
 
   def workload
     indent_lines([

--- a/exercises/say/.meta/generator/say_cases.rb
+++ b/exercises/say/.meta/generator/say_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class SayCase < ExerciseCase
+class SayCase < Generator::ExerciseCase
 
   def workload
     [

--- a/exercises/sieve/.meta/generator/sieve_cases.rb
+++ b/exercises/sieve/.meta/generator/sieve_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class SieveCase < ExerciseCase
+class SieveCase < Generator::ExerciseCase
   OPEN_ARRAY = "[\n\s\s\s\s\s\s".freeze
   CLOSE_ARRAY = "\n\s\s\s\s]".freeze
   NEW_ARRAY_ROW = ",\n\s\s\s\s\s\s".freeze

--- a/exercises/tournament/.meta/generator/tournament_cases.rb
+++ b/exercises/tournament/.meta/generator/tournament_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class TournamentCase < ExerciseCase
+class TournamentCase < Generator::ExerciseCase
 
   def workload
     'Tournament.tally(input)'

--- a/exercises/transpose/.meta/generator/transpose_cases.rb
+++ b/exercises/transpose/.meta/generator/transpose_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class TransposeCase < ExerciseCase
+class TransposeCase < Generator::ExerciseCase
 
   def workload
     'Transpose.transpose(input)'

--- a/exercises/triangle/.meta/generator/triangle_cases.rb
+++ b/exercises/triangle/.meta/generator/triangle_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class TriangleCase < ExerciseCase
+class TriangleCase < Generator::ExerciseCase
   def name
     initial = description.downcase
     replaced = initial.gsub(/(true|false)/, expected_type)

--- a/exercises/two-bucket/.meta/generator/two_bucket_cases.rb
+++ b/exercises/two-bucket/.meta/generator/two_bucket_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class TwoBucketCase < ExerciseCase
+class TwoBucketCase < Generator::ExerciseCase
   def name
     "test_bucket_one_size_#{bucket_one}_bucket_two_"\
     "size_#{bucket_two}_goal_#{goal}_start_with_bucket_#{start_bucket}"

--- a/exercises/word-count/.meta/generator/word_count_cases.rb
+++ b/exercises/word-count/.meta/generator/word_count_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class WordCountCase < ExerciseCase
+class WordCountCase < Generator::ExerciseCase
 
   def workload
     indent_lines([

--- a/exercises/wordy/.meta/generator/wordy_cases.rb
+++ b/exercises/wordy/.meta/generator/wordy_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class WordyCase < ExerciseCase
+class WordyCase < Generator::ExerciseCase
 
   def workload
     [

--- a/lib/generator/exercise_case/assertion.rb
+++ b/lib/generator/exercise_case/assertion.rb
@@ -1,0 +1,33 @@
+module Generator
+  class ExerciseCase < OpenStruct
+    module Assertion
+      # e.g.,
+      #   "#{assert} Luhn.valid?(#{input.inspect})"
+      def assert
+        expected ? 'assert' : 'refute'
+      end
+
+      # e.g.,
+      #   assert_equal { "PigLatin.translate(#{input.inspect})" }
+      def assert_equal
+        "assert_equal #{expected.inspect}, #{yield}"
+      end
+
+      # e.g.,
+      #   if raises_error?
+      #     assert_raises(ArgumentError) { test_case }
+      #   else
+      #     assert_equal { test_case }
+      #   end
+      def raises_error?
+        expected.to_i == -1
+      end
+
+      # e.g.,
+      #   assert_raises(ArgumentError) { test_case }
+      def assert_raises(error)
+        "assert_raises(#{error}) { #{yield} }"
+      end
+    end
+  end
+end

--- a/lib/generator/exercise_case/assertion.rb
+++ b/lib/generator/exercise_case/assertion.rb
@@ -1,8 +1,8 @@
 module Generator
   class ExerciseCase < OpenStruct
     module Assertion
-      # e.g.,
-      #   "#{assert} Luhn.valid?(#{input.inspect})"
+
+      #  "#{assert} Luhn.valid?(#{input.inspect})"
       def assert
         expected ? 'assert' : 'refute'
       end

--- a/lib/generator/exercise_cases.rb
+++ b/lib/generator/exercise_cases.rb
@@ -46,33 +46,5 @@ module Generator
         delimiter
       ].join("\n")
     end
-
-    # e.g.,
-    #   "#{assert} Luhn.valid?(#{input.inspect})"
-    def assert
-      expected ? 'assert' : 'refute'
-    end
-
-    # e.g.,
-    #   assert_equal { "PigLatin.translate(#{input.inspect})" }
-    def assert_equal
-      "assert_equal #{expected.inspect}, #{yield}"
-    end
-
-    # e.g.,
-    #   if raises_error?
-    #     assert_raises(ArgumentError) { test_case }
-    #   else
-    #     assert_equal { test_case }
-    #   end
-    def raises_error?
-      expected.to_i == -1
-    end
-
-    # e.g.,
-    #   assert_raises(ArgumentError) { test_case }
-    def assert_raises(error)
-      "assert_raises(#{error}) { #{yield} }"
-    end
   end
 end

--- a/lib/generator/exercise_cases.rb
+++ b/lib/generator/exercise_cases.rb
@@ -37,7 +37,9 @@ module Generator
     end
 
     # generate heredoc (as part of workload) with optional indentation
-    def indented_heredoc(lines, delimiter, depth = 0, delimiter_method = nil)
+    #
+    #    indent_heredoc(["foo", "bar"], 'TEXT', 1)
+    def indent_heredoc(lines, delimiter, depth = 0, delimiter_method = nil)
       [
         "<<-#{delimiter}#{delimiter_method}",
         lines.map { |line| ' ' * depth + line }.join("\n"),

--- a/lib/generator/exercise_cases.rb
+++ b/lib/generator/exercise_cases.rb
@@ -27,11 +27,11 @@ module Generator
       code.join(separator + ' ' * depth)
     end
 
-    # indent multi line workloads with blank lines
+    # indent multi line workloads with (unindented) blank lines
     #
-    #   indent_text(4, lines.join("\n"))
-    def indent_text(depth, text)
-      text.lines.reduce do |obj, line|
+    #   indent_text(4, lines)
+    def indent_text(depth, lines)
+      lines.reduce do |obj, line|
         obj << (line == "\n" ? line : ' ' * depth + line)
       end
     end

--- a/test/fixtures/xruby/exercises/beta/.meta/generator/beta_cases.rb
+++ b/test/fixtures/xruby/exercises/beta/.meta/generator/beta_cases.rb
@@ -1,6 +1,6 @@
 require 'generator/exercise_cases'
 
-class BetaCase < ExerciseCase
+class BetaCase < Generator::ExerciseCase
   def workload
     assert_equal { "Beta.call('#{input}')" }
   end

--- a/test/generator/case_values_test.rb
+++ b/test/generator/case_values_test.rb
@@ -1,12 +1,12 @@
 require_relative '../test_helper'
 
-class ComplexCase < ExerciseCase
-  def workload
-    assert { Complex.foo(bar) }
-  end
-end
-
 module Generator
+  class ComplexCase < ExerciseCase
+    def workload
+      assert { Complex.foo(bar) }
+    end
+  end
+
   module CaseValues
     class ExtractorTest < Minitest::Test
       def test_multi_level_auto_extraction

--- a/test/generator/exercise_case/assertion_test.rb
+++ b/test/generator/exercise_case/assertion_test.rb
@@ -1,0 +1,13 @@
+require_relative '../../test_helper'
+
+module Generator
+  class ExerciseCase
+    class AssertionTest < Minitest::Test
+      def test_assert
+        test_case = OpenStruct.new(expected: true)
+        test_case.extend(Assertion)
+        assert_equal 'assert', test_case.assert
+      end
+    end
+  end
+end

--- a/test/generator/exercise_case/assertion_test.rb
+++ b/test/generator/exercise_case/assertion_test.rb
@@ -15,6 +15,12 @@ module Generator
         assert_equal 'refute', test_case.assert
       end
 
+      def test_assert_equal
+        test_case = OpenStruct.new(expected: 2)
+        test_case.extend(Assertion)
+        assert_equal "assert_equal 2, 4", test_case.assert_equal { 1 + 3 }
+      end
+
     end
   end
 end

--- a/test/generator/exercise_case/assertion_test.rb
+++ b/test/generator/exercise_case/assertion_test.rb
@@ -32,6 +32,15 @@ module Generator
         test_case.extend(Assertion)
         refute test_case.raises_error?
       end
+
+      def test_assert_raises
+        test_case = OpenStruct.new
+        test_case.extend(Assertion)
+        assert_equal(
+          "assert_raises(ArgumentError) { 4 }",
+          test_case.assert_raises(ArgumentError) { 2 + 2 }
+        )
+      end
     end
   end
 end

--- a/test/generator/exercise_case/assertion_test.rb
+++ b/test/generator/exercise_case/assertion_test.rb
@@ -8,6 +8,13 @@ module Generator
         test_case.extend(Assertion)
         assert_equal 'assert', test_case.assert
       end
+
+      def test_refute
+        test_case = OpenStruct.new(expected: false)
+        test_case.extend(Assertion)
+        assert_equal 'refute', test_case.assert
+      end
+
     end
   end
 end

--- a/test/generator/exercise_case/assertion_test.rb
+++ b/test/generator/exercise_case/assertion_test.rb
@@ -21,6 +21,17 @@ module Generator
         assert_equal "assert_equal 2, 4", test_case.assert_equal { 1 + 3 }
       end
 
+      def test_raises_error
+        test_case = OpenStruct.new(expected: -1)
+        test_case.extend(Assertion)
+        assert test_case.raises_error?
+      end
+
+      def test_does_not_raise_error
+        test_case = OpenStruct.new(expected: 'cute kitties')
+        test_case.extend(Assertion)
+        refute test_case.raises_error?
+      end
     end
   end
 end

--- a/test/generator/exercise_cases_test.rb
+++ b/test/generator/exercise_cases_test.rb
@@ -14,14 +14,24 @@ module Generator
       assert_equal 'skip', ExerciseCase.new(index: 12).skipped
     end
 
-    class MyCase < ExerciseCase
+    class MultiLineCase < ExerciseCase
       def workload
         indent_lines(['foo','bar'], 1)
       end
     end
     def test_indent_multiline_workloads
       expected = "foo\n bar"
-      assert_equal expected, MyCase.new.workload
+      assert_equal expected, MultiLineCase.new.workload
+    end
+
+    class BlankLineCase < ExerciseCase
+      def workload
+        indent_text(2, ["foo\n", "\n", "bar\n"])
+      end
+    end
+    def test_indent_multiline_workloads_with_blank_lines
+      expected = "foo\n\n  bar\n"
+      assert_equal expected, BlankLineCase.new.workload
     end
   end
 end

--- a/test/generator/exercise_cases_test.rb
+++ b/test/generator/exercise_cases_test.rb
@@ -1,0 +1,17 @@
+require_relative '../test_helper'
+
+module Generator
+  class ExerciseCaseTest < Minitest::Test
+    def test_name
+      assert_equal 'test_foo', ExerciseCase.new(description: 'foo').name
+    end
+
+    def test_skipped_index_zero
+      assert_equal '# skip', ExerciseCase.new(index: 0).skipped
+    end
+
+    def test_skipped_index_nonzero
+      assert_equal 'skip', ExerciseCase.new(index: 12).skipped
+    end
+  end
+end

--- a/test/generator/exercise_cases_test.rb
+++ b/test/generator/exercise_cases_test.rb
@@ -33,5 +33,15 @@ module Generator
       expected = "foo\n\n  bar\n"
       assert_equal expected, BlankLineCase.new.workload
     end
+
+    class HeredocCase < ExerciseCase
+      def workload
+        indent_heredoc(["foo", "bar"], 'TEXT', 1)
+      end
+    end
+    def test_heredoc
+      expected = "<<-TEXT\n foo\n bar\nTEXT"
+      assert_equal expected, HeredocCase.new.workload
+    end
   end
 end

--- a/test/generator/exercise_cases_test.rb
+++ b/test/generator/exercise_cases_test.rb
@@ -16,7 +16,7 @@ module Generator
 
     class MultiLineCase < ExerciseCase
       def workload
-        indent_lines(['foo','bar'], 1)
+        indent_lines(['foo', 'bar'], 1)
       end
     end
     def test_indent_multiline_workloads

--- a/test/generator/exercise_cases_test.rb
+++ b/test/generator/exercise_cases_test.rb
@@ -13,5 +13,15 @@ module Generator
     def test_skipped_index_nonzero
       assert_equal 'skip', ExerciseCase.new(index: 12).skipped
     end
+
+    class MyCase < ExerciseCase
+      def workload
+        indent_lines(['foo','bar'], 1)
+      end
+    end
+    def test_indent_multiline_workloads
+      expected = "foo\n bar"
+      assert_equal expected, MyCase.new.workload
+    end
   end
 end


### PR DESCRIPTION
Separating out the changes to ExerciseCase from moving the test templates.... 

This PR goes before exercism/xruby#585

I also:
* moved `ExerciseCase` under the `Generator` module (and gave thanks for `sed`)
* moved the assert helper methods out into their own module, for ease of testing and because `ExerciseCase` was becoming bloated.
* added test coverage for `ExerciseCase`
