### PR TITLE
run-length-encoding: Remove redundant test

### DIFF
--- a/exercises/run-length-encoding/run_length_encoding_test.rb
+++ b/exercises/run-length-encoding/run_length_encoding_test.rb
@@ -47,13 +47,6 @@ class RunLengthEncodingTest < Minitest::Test
     assert_equal output, RunLengthEncoding.encode(input)
   end
 
-  def test_empty_string
-    skip
-    input = ''
-    output = ''
-    assert_equal output, RunLengthEncoding.decode(input)
-  end
-
   def test_single_characters_only
     skip
     input = 'XYZ'


### PR DESCRIPTION
Because there are two tests with the same name (see line 9), Minitest incorrectly infers that the test is skipped, not that it is passing or failing, when the user first runs the test suite.