### PR TITLE
run-length-encoding: Add property to generated tests

### DIFF
--- a/exercises/run-length-encoding/.meta/generator/run_length_encoding_cases.rb
+++ b/exercises/run-length-encoding/.meta/generator/run_length_encoding_cases.rb
@@ -2,6 +2,10 @@ require 'generator/exercise_cases'
 
 class RunLengthEncodingCase < Generator::ExerciseCase
 
+  def name
+    super.sub('test_',"test_#{property}_")
+  end
+
   def workload
     indent_lines([
       "input = '#{input}'",

--- a/exercises/run-length-encoding/run_length_encoding_test.rb
+++ b/exercises/run-length-encoding/run_length_encoding_test.rb
@@ -5,91 +5,91 @@ require_relative 'run_length_encoding'
 
 # Common test data version: 503a57a
 class RunLengthEncodingTest < Minitest::Test
-  def test_empty_string
+  def test_encode_empty_string
     # skip
     input = ''
     output = ''
     assert_equal output, RunLengthEncoding.encode(input)
   end
 
-  def test_single_characters_only_are_encoded_without_count
+  def test_encode_single_characters_only_are_encoded_without_count
     skip
     input = 'XYZ'
     output = 'XYZ'
     assert_equal output, RunLengthEncoding.encode(input)
   end
 
-  def test_string_with_no_single_characters
+  def test_encode_string_with_no_single_characters
     skip
     input = 'AABBBCCCC'
     output = '2A3B4C'
     assert_equal output, RunLengthEncoding.encode(input)
   end
 
-  def test_single_characters_mixed_with_repeated_characters
+  def test_encode_single_characters_mixed_with_repeated_characters
     skip
     input = 'WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB'
     output = '12WB12W3B24WB'
     assert_equal output, RunLengthEncoding.encode(input)
   end
 
-  def test_multiple_whitespace_mixed_in_string
+  def test_encode_multiple_whitespace_mixed_in_string
     skip
     input = '  hsqq qww  '
     output = '2 hs2q q2w2 '
     assert_equal output, RunLengthEncoding.encode(input)
   end
 
-  def test_lowercase_characters
+  def test_encode_lowercase_characters
     skip
     input = 'aabbbcccc'
     output = '2a3b4c'
     assert_equal output, RunLengthEncoding.encode(input)
   end
 
-  def test_empty_string
+  def test_decode_empty_string
     skip
     input = ''
     output = ''
     assert_equal output, RunLengthEncoding.decode(input)
   end
 
-  def test_single_characters_only
+  def test_decode_single_characters_only
     skip
     input = 'XYZ'
     output = 'XYZ'
     assert_equal output, RunLengthEncoding.decode(input)
   end
 
-  def test_string_with_no_single_characters
+  def test_decode_string_with_no_single_characters
     skip
     input = '2A3B4C'
     output = 'AABBBCCCC'
     assert_equal output, RunLengthEncoding.decode(input)
   end
 
-  def test_single_characters_with_repeated_characters
+  def test_decode_single_characters_with_repeated_characters
     skip
     input = '12WB12W3B24WB'
     output = 'WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB'
     assert_equal output, RunLengthEncoding.decode(input)
   end
 
-  def test_multiple_whitespace_mixed_in_string
+  def test_decode_multiple_whitespace_mixed_in_string
     skip
     input = '2 hs2q q2w2 '
     output = '  hsqq qww  '
     assert_equal output, RunLengthEncoding.decode(input)
   end
 
-  def test_lower_case_string
+  def test_decode_lower_case_string
     skip
     input = '2a3b4c'
     output = 'aabbbcccc'
     assert_equal output, RunLengthEncoding.decode(input)
   end
 
-  def test_encode_followed_by_decode_gives_original_string
+  def test_consistency_encode_followed_by_decode_gives_original_string
     skip
     input = 'zzz ZZ  zZ'
     output = 'zzz ZZ  zZ'


### PR DESCRIPTION
Resolves #588 

* Update the test generator to add `encode_` or `decode_` as a prefix to all tests depending on the method being tested.
This fixes a name collision bug between:
def `test_empty_string` for encode
and
def `test_empty_string` for decode

* Regenerated tests.
