### PR TITLE
exercise_cases: Use assert_nil when expected is nil

### DIFF
--- a/lib/generator/exercise_case/assertion.rb
+++ b/lib/generator/exercise_case/assertion.rb
@@ -10,7 +10,8 @@ module Generator
       # e.g.,
       #   assert_equal { "PigLatin.translate(#{input.inspect})" }
       def assert_equal
-        "assert_equal #{expected.inspect}, #{yield}"
+        assertion = expected.nil? ? 'assert_nil' : "assert_equal #{expected.inspect},"
+        "#{assertion} #{yield}"
       end
 
       # e.g.,

--- a/test/generator/exercise_case/assertion_test.rb
+++ b/test/generator/exercise_case/assertion_test.rb
@@ -21,6 +21,12 @@ module Generator
         assert_equal "assert_equal 2, 4", test_case.assert_equal { 1 + 3 }
       end
 
+      def test_assert_equal_when_nil
+        test_case = OpenStruct.new(expected: nil)
+        test_case.extend(Assertion)
+        assert_equal "assert_nil 4", test_case.assert_equal { 1 + 3 }
+      end
+
       def test_raises_error
         test_case = OpenStruct.new(expected: -1)
         test_case.extend(Assertion)


### PR DESCRIPTION
Minitest will emit a warning if `assert_equal` is used when the expected value is `nil`
This patch updates the cases generator to use `assert_nil` instead of `assert_equal` when the expected value is `nil`

