### PR TITLE
Remove redundant gem 'minitest', '>= 5.0.0' line.

### DIFF
--- a/exercises/accumulate/accumulate_test.rb
+++ b/exercises/accumulate/accumulate_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'accumulate'
 

--- a/exercises/acronym/acronym_test.rb
+++ b/exercises/acronym/acronym_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'acronym'
 

--- a/exercises/all-your-base/all_your_base_test.rb
+++ b/exercises/all-your-base/all_your_base_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'all_your_base'
 

--- a/exercises/allergies/allergies_test.rb
+++ b/exercises/allergies/allergies_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'allergies'
 

--- a/exercises/alphametics/.meta/generator/test_template.erb
+++ b/exercises/alphametics/.meta/generator/test_template.erb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'alphametics'
 

--- a/exercises/alphametics/alphametics_test.rb
+++ b/exercises/alphametics/alphametics_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'alphametics'
 

--- a/exercises/anagram/anagram_test.rb
+++ b/exercises/anagram/anagram_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'anagram'
 

--- a/exercises/atbash-cipher/atbash_cipher_test.rb
+++ b/exercises/atbash-cipher/atbash_cipher_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'atbash_cipher'
 

--- a/exercises/beer-song/beer_song_test.rb
+++ b/exercises/beer-song/beer_song_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'beer_song'
 

--- a/exercises/binary-search-tree/binary_search_tree_test.rb
+++ b/exercises/binary-search-tree/binary_search_tree_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'binary_search_tree'
 

--- a/exercises/binary-search/binary_search_test.rb
+++ b/exercises/binary-search/binary_search_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'binary_search'
 

--- a/exercises/binary/binary_test.rb
+++ b/exercises/binary/binary_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'binary'
 

--- a/exercises/bob/bob_test.rb
+++ b/exercises/bob/bob_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'bob'
 

--- a/exercises/bowling/.meta/generator/test_template.erb
+++ b/exercises/bowling/.meta/generator/test_template.erb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'bowling'
 

--- a/exercises/bowling/bowling_test.rb
+++ b/exercises/bowling/bowling_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'bowling'
 

--- a/exercises/bracket-push/bracket_push_test.rb
+++ b/exercises/bracket-push/bracket_push_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'bracket_push'
 

--- a/exercises/circular-buffer/circular_buffer_test.rb
+++ b/exercises/circular-buffer/circular_buffer_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'circular_buffer'
 

--- a/exercises/clock/clock_test.rb
+++ b/exercises/clock/clock_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'clock'
 

--- a/exercises/connect/.meta/generator/test_template.erb
+++ b/exercises/connect/.meta/generator/test_template.erb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'connect'
 

--- a/exercises/connect/connect_test.rb
+++ b/exercises/connect/connect_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'connect'
 

--- a/exercises/crypto-square/crypto_square_test.rb
+++ b/exercises/crypto-square/crypto_square_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'crypto_square'
 

--- a/exercises/custom-set/custom_set_test.rb
+++ b/exercises/custom-set/custom_set_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'custom_set'
 

--- a/exercises/diamond/diamond_test.rb
+++ b/exercises/diamond/diamond_test.rb
@@ -1,5 +1,4 @@
 # !/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'diamond'
 

--- a/exercises/difference-of-squares/difference_of_squares_test.rb
+++ b/exercises/difference-of-squares/difference_of_squares_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'difference_of_squares'
 

--- a/exercises/dominoes/.meta/generator/test_template.erb
+++ b/exercises/dominoes/.meta/generator/test_template.erb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'dominoes'
 

--- a/exercises/dominoes/dominoes_test.rb
+++ b/exercises/dominoes/dominoes_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'dominoes'
 

--- a/exercises/etl/etl_test.rb
+++ b/exercises/etl/etl_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'etl'
 

--- a/exercises/flatten-array/flatten_array_test.rb
+++ b/exercises/flatten-array/flatten_array_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'flatten_array'
 

--- a/exercises/food-chain/food_chain_test.rb
+++ b/exercises/food-chain/food_chain_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 
 require_relative 'food_chain'

--- a/exercises/gigasecond/gigasecond_test.rb
+++ b/exercises/gigasecond/gigasecond_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'gigasecond'
 

--- a/exercises/grade-school/grade_school_test.rb
+++ b/exercises/grade-school/grade_school_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'grade_school'
 

--- a/exercises/grains/grains_test.rb
+++ b/exercises/grains/grains_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'grains'
 

--- a/exercises/hamming/hamming_test.rb
+++ b/exercises/hamming/hamming_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'hamming'
 

--- a/exercises/hexadecimal/hexadecimal_test.rb
+++ b/exercises/hexadecimal/hexadecimal_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'hexadecimal'
 

--- a/exercises/house/house_test.rb
+++ b/exercises/house/house_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'house'
 

--- a/exercises/isogram/isogram_test.rb
+++ b/exercises/isogram/isogram_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'isogram'
 

--- a/exercises/kindergarten-garden/kindergarten_garden_test.rb
+++ b/exercises/kindergarten-garden/kindergarten_garden_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'kindergarten_garden'
 

--- a/exercises/largest-series-product/largest_series_product_test.rb
+++ b/exercises/largest-series-product/largest_series_product_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'largest_series_product'
 

--- a/exercises/leap/.meta/generator/test_template.erb
+++ b/exercises/leap/.meta/generator/test_template.erb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'leap'
 

--- a/exercises/leap/leap_test.rb
+++ b/exercises/leap/leap_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'leap'
 

--- a/exercises/linked-list/linked_list_test.rb
+++ b/exercises/linked-list/linked_list_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'linked_list'
 

--- a/exercises/list-ops/list_ops_test.rb
+++ b/exercises/list-ops/list_ops_test.rb
@@ -1,4 +1,3 @@
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'list_ops'
 

--- a/exercises/luhn/luhn_test.rb
+++ b/exercises/luhn/luhn_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'luhn'
 

--- a/exercises/matrix/matrix_test.rb
+++ b/exercises/matrix/matrix_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'matrix'
 

--- a/exercises/meetup/meetup_test.rb
+++ b/exercises/meetup/meetup_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require 'date'
 require_relative 'meetup'

--- a/exercises/minesweeper/minesweeper_test.rb
+++ b/exercises/minesweeper/minesweeper_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'minesweeper'
 

--- a/exercises/nth-prime/nth_prime_test.rb
+++ b/exercises/nth-prime/nth_prime_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'nth_prime'
 

--- a/exercises/nucleotide-count/nucleotide_count_test.rb
+++ b/exercises/nucleotide-count/nucleotide_count_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'nucleotide_count'
 

--- a/exercises/ocr-numbers/ocr_numbers_test.rb
+++ b/exercises/ocr-numbers/ocr_numbers_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'ocr_numbers'
 

--- a/exercises/octal/octal_test.rb
+++ b/exercises/octal/octal_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'octal'
 

--- a/exercises/palindrome-products/palindrome_products_test.rb
+++ b/exercises/palindrome-products/palindrome_products_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'palindrome_products'
 

--- a/exercises/pangram/pangram_test.rb
+++ b/exercises/pangram/pangram_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'pangram'
 

--- a/exercises/pascals-triangle/pascals_triangle_test.rb
+++ b/exercises/pascals-triangle/pascals_triangle_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'pascals_triangle'
 

--- a/exercises/perfect-numbers/perfect_numbers_test.rb
+++ b/exercises/perfect-numbers/perfect_numbers_test.rb
@@ -1,4 +1,3 @@
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'perfect_numbers'
 

--- a/exercises/phone-number/phone_number_test.rb
+++ b/exercises/phone-number/phone_number_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'phone_number'
 

--- a/exercises/pig-latin/pig_latin_test.rb
+++ b/exercises/pig-latin/pig_latin_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'pig_latin'
 

--- a/exercises/point-mutations/point_mutations_test.rb
+++ b/exercises/point-mutations/point_mutations_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'point_mutations'
 

--- a/exercises/poker/poker_test.rb
+++ b/exercises/poker/poker_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'poker'
 

--- a/exercises/prime-factors/prime_factors_test.rb
+++ b/exercises/prime-factors/prime_factors_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'prime_factors'
 

--- a/exercises/protein-translation/protein_translation_test.rb
+++ b/exercises/protein-translation/protein_translation_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'protein_translation'
 

--- a/exercises/proverb/proverb_test.rb
+++ b/exercises/proverb/proverb_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'proverb'
 

--- a/exercises/pythagorean-triplet/pythagorean_triplet_test.rb
+++ b/exercises/pythagorean-triplet/pythagorean_triplet_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'pythagorean_triplet'
 

--- a/exercises/queen-attack/queen_attack_test.rb
+++ b/exercises/queen-attack/queen_attack_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'queen_attack'
 

--- a/exercises/rail-fence-cipher/rail_fence_cipher_test.rb
+++ b/exercises/rail-fence-cipher/rail_fence_cipher_test.rb
@@ -1,4 +1,3 @@
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'rail_fence_cipher'
 

--- a/exercises/raindrops/raindrops_test.rb
+++ b/exercises/raindrops/raindrops_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'raindrops'
 

--- a/exercises/rna-transcription/rna_transcription_test.rb
+++ b/exercises/rna-transcription/rna_transcription_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'rna_transcription'
 

--- a/exercises/robot-name/robot_name_test.rb
+++ b/exercises/robot-name/robot_name_test.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: false
 
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'robot_name'
 

--- a/exercises/robot-simulator/robot_simulator_test.rb
+++ b/exercises/robot-simulator/robot_simulator_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'robot_simulator'
 

--- a/exercises/roman-numerals/roman_numerals_test.rb
+++ b/exercises/roman-numerals/roman_numerals_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'roman_numerals'
 

--- a/exercises/run-length-encoding/run_length_encoding_test.rb
+++ b/exercises/run-length-encoding/run_length_encoding_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'run_length_encoding'
 

--- a/exercises/saddle-points/saddle_points_test.rb
+++ b/exercises/saddle-points/saddle_points_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'saddle_points'
 

--- a/exercises/say/say_test.rb
+++ b/exercises/say/say_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'say'
 

--- a/exercises/scale-generator/scale_generator_test.rb
+++ b/exercises/scale-generator/scale_generator_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'scale_generator'
 

--- a/exercises/scrabble-score/scrabble_score_test.rb
+++ b/exercises/scrabble-score/scrabble_score_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'scrabble_score'
 

--- a/exercises/secret-handshake/secret_handshake_test.rb
+++ b/exercises/secret-handshake/secret_handshake_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'secret_handshake'
 

--- a/exercises/series/series_test.rb
+++ b/exercises/series/series_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'series'
 

--- a/exercises/sieve/sieve_test.rb
+++ b/exercises/sieve/sieve_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'sieve'
 

--- a/exercises/simple-cipher/simple_cipher_test.rb
+++ b/exercises/simple-cipher/simple_cipher_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'simple_cipher'
 

--- a/exercises/space-age/space_age_test.rb
+++ b/exercises/space-age/space_age_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'space_age'
 

--- a/exercises/strain/strain_test.rb
+++ b/exercises/strain/strain_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'strain'
 

--- a/exercises/sum-of-multiples/sum_of_multiples_test.rb
+++ b/exercises/sum-of-multiples/sum_of_multiples_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'sum_of_multiples'
 

--- a/exercises/tournament/tournament_test.rb
+++ b/exercises/tournament/tournament_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'tournament'
 

--- a/exercises/transpose/transpose_test.rb
+++ b/exercises/transpose/transpose_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'transpose'
 

--- a/exercises/triangle/triangle_test.rb
+++ b/exercises/triangle/triangle_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'triangle'
 

--- a/exercises/trinary/trinary_test.rb
+++ b/exercises/trinary/trinary_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'trinary'
 

--- a/exercises/twelve-days/twelve_days_test.rb
+++ b/exercises/twelve-days/twelve_days_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'twelve_days'
 

--- a/exercises/two-bucket/two_bucket_test.rb
+++ b/exercises/two-bucket/two_bucket_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'two_bucket'
 

--- a/exercises/word-count/word_count_test.rb
+++ b/exercises/word-count/word_count_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'word_count'
 

--- a/exercises/wordy/wordy_test.rb
+++ b/exercises/wordy/wordy_test.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'wordy'
 

--- a/lib/generator/test_template.erb
+++ b/lib/generator/test_template.erb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative '<%= exercise_name %>'
 

--- a/test/fixtures/xruby/exercises/alpha/.meta/generator/test_template.erb
+++ b/test/fixtures/xruby/exercises/alpha/.meta/generator/test_template.erb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative '<%= exercise_name %>'
 

--- a/test/fixtures/xruby/exercises/beta/example.tt
+++ b/test/fixtures/xruby/exercises/beta/example.tt
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative '<%= exercise_name %>'
 

--- a/test/fixtures/xruby/lib/generator/test_template.erb
+++ b/test/fixtures/xruby/lib/generator/test_template.erb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'acronym'
 


### PR DESCRIPTION
Many of the test files contain the line:
```
gem 'minitest', '>= 5.0.0'
```
This line is is unnecessary and can be removed.


Fixes: https://github.com/exercism/xruby/issues/587