### PR TITLE
generators: Add canonical data version to test templates

### DIFF
--- a/exercises/alphametics/.meta/generator/test_template.erb
+++ b/exercises/alphametics/.meta/generator/test_template.erb
@@ -3,7 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'alphametics'
 
-# Common test data version: <%= abbreviated_commit_hash %>
+# Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
 class AlphameticsTest < Minitest::Test
 <% test_cases.each do |test_case| %>
 

--- a/exercises/bowling/.meta/generator/test_template.erb
+++ b/exercises/bowling/.meta/generator/test_template.erb
@@ -3,7 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'bowling'
 
-# Common test data version: <%= abbreviated_commit_hash %>
+# Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
 class BowlingTest < Minitest::Test
   def setup
     @game = Game.new

--- a/exercises/connect/.meta/generator/test_template.erb
+++ b/exercises/connect/.meta/generator/test_template.erb
@@ -3,7 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'connect'
 
-# Common test data version: <%= abbreviated_commit_hash %>
+# Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
 class ConnectTest < Minitest::Test
 <% test_cases.each do |test_case| %>
   <%= test_case.ignore_method_length%>def <%= test_case.name %>

--- a/exercises/dominoes/.meta/generator/test_template.erb
+++ b/exercises/dominoes/.meta/generator/test_template.erb
@@ -3,7 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'dominoes'
 
-# Common test data version: <%= abbreviated_commit_hash %>
+# Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
 class DominoesTest < Minitest::Test
 <% test_cases.each do |test_case| %>
   def <%= test_case.name %>

--- a/exercises/hello-world/.meta/generator/test_template.erb
+++ b/exercises/hello-world/.meta/generator/test_template.erb
@@ -12,7 +12,7 @@ rescue LoadError => e
   exit 1
 end
 
-# Common test data version: <%= abbreviated_commit_hash %>
+# Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
 class HelloWorldTest < Minitest::Test
 <% test_cases.each do |test_case| %>
   def <%= test_case.name %>

--- a/exercises/leap/.meta/generator/test_template.erb
+++ b/exercises/leap/.meta/generator/test_template.erb
@@ -3,7 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative 'leap'
 
-# Common test data version: <%= abbreviated_commit_hash %>
+# Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
 class Date
   def leap?
     raise RuntimeError, "Implement this yourself instead of using Ruby's implementation."

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -1,13 +1,14 @@
 module Generator
   # Contains methods accessible to the ERB template
   class TemplateValues
-    attr_reader :abbreviated_commit_hash, :version, :exercise_name, :test_cases
+    attr_reader :abbreviated_commit_hash, :version, :exercise_name, :test_cases, :canonical_data_version
 
-    def initialize(abbreviated_commit_hash:, version:, exercise_name:, test_cases:)
+    def initialize(abbreviated_commit_hash:, version:, exercise_name:, test_cases:, canonical_data_version: nil)
       @abbreviated_commit_hash = abbreviated_commit_hash
       @version = version
       @exercise_name = exercise_name ? exercise_name.tr('-_', '_') : ''
       @test_cases = test_cases
+      @canonical_data_version = canonical_data_version
     end
 
     def get_binding
@@ -23,6 +24,7 @@ module Generator
     def template_values
       TemplateValues.new(
         abbreviated_commit_hash: canonical_data.abbreviated_commit_hash,
+        canonical_data_version: canonical_data.version,
         version: version,
         exercise_name: exercise_name,
         test_cases: extract

--- a/lib/generator/test_template.erb
+++ b/lib/generator/test_template.erb
@@ -3,7 +3,7 @@ gem 'minitest', '>= 5.0.0'
 require 'minitest/autorun'
 require_relative '<%= exercise_name %>'
 
-# Common test data version: <%= abbreviated_commit_hash %>
+# Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
 class <%= exercise_name_camel %>Test < Minitest::Test
 <% test_cases.each do |test_case| %>
   def <%= test_case.name %>

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -57,6 +57,7 @@ module Generator
       def canonical_data
         mock_canonical_data = Minitest::Mock.new
         mock_canonical_data.expect :abbreviated_commit_hash, nil
+        mock_canonical_data.expect :version, '1.2.3'
         mock_canonical_data.expect :to_s, '{"cases":[]}'
         mock_canonical_data
       end
@@ -82,6 +83,7 @@ module Generator
       def canonical_data
         mock_canonical_data = Minitest::Mock.new
         mock_canonical_data.expect :abbreviated_commit_hash, nil
+        mock_canonical_data.expect :version, '1.2.3'
         mock_canonical_data.expect :to_s, '{"cases":[]}'
         mock_canonical_data
       end


### PR DESCRIPTION
The version string comes from the 'version' key of the canonical-data.json file.
It is a requirement that all canonical-data files have this key.

Displaying this version makes it easier to see which version of the canonical tests were used to generate a particular test file.

This patch does not regenerate the tests to include this version information, but it will be included next time the tests are generated.

Ref: https://github.com/exercism/xruby/issues/485