### PR TITLE
generator: remove support for legacy test template location

### DIFF
--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -32,11 +32,8 @@ module Generator
       end
 
       def tests_template_absolute_filename
-        case
-        when File.exist?(track_tests_template_filename) then track_tests_template_filename
-        when File.exist?(legacy_tests_template_filename) then legacy_tests_template_filename
-        else default_tests_template_filename
-        end
+        File.exist?(track_tests_template_filename) ? track_tests_template_filename :
+          default_tests_template_filename
       end
 
       def track_tests_template_filename
@@ -45,10 +42,6 @@ module Generator
 
       def default_tests_template_filename
         File.join(paths.track, 'lib', 'generator', tests_template_filename)
-      end
-
-      def legacy_tests_template_filename
-        File.join(exercise_path, 'example.tt')
       end
 
       def tests_template_filename

--- a/test/generator/files/track_files_test.rb
+++ b/test/generator/files/track_files_test.rb
@@ -52,21 +52,6 @@ module Generator
         expected_filename = FixturePaths.track + '/lib/generator/test_template.erb'
         assert_equal expected_filename, subject.tests_template.filename
       end
-
-      class TestTrackFilesUseLegacy
-        def initialize
-          @paths = FixturePaths
-          @exercise_name = 'beta'
-        end
-        attr_reader :paths, :exercise_name
-        include TrackFiles
-      end
-
-      def test_legacy_tests_template
-        subject = TestTrackFilesUseLegacy.new
-        expected_filename = FixturePaths.track + '/exercises/beta/example.tt'
-        assert_equal expected_filename, subject.tests_template.filename
-      end
     end
 
     class TestsVersionFileTest < Minitest::Test


### PR DESCRIPTION
Part of generator improvements (exercism/xruby#485)

Last step in moving test templates to `.meta`.

