### PR TITLE
phone-number: Re add canonical_data_version

### DIFF
--- a/exercises/phone-number/phone_number_test.rb
+++ b/exercises/phone-number/phone_number_test.rb
@@ -2,7 +2,7 @@
 require 'minitest/autorun'
 require_relative 'phone_number'
 
-# Common test data version: 51d2475
+# Common test data version: 1.1.0 51d2475
 class PhoneNumberTest < Minitest::Test
   def test_cleans_the_number
     # skip


### PR DESCRIPTION
`phone_number_test.rb` lost its canonical data version number in all the excitement yesterday.

This patch adds it back in.