### PR TITLE
config.json: Add alternate solution location pattern.

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/exercism/xruby",
   "active": true,
   "gitter": "xruby",
-  "solutionpattern": "\\.meta/solutions/[^/]*\\.rb",
+  "solutionpattern": "[Ee]xample|\\.meta/solutions/[^/]*\\.rb",
   "exercises": [
     {
       "slug": "hello-world",

--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/exercism/xruby",
   "active": true,
   "gitter": "xruby",
+  "solutionpattern": "\\.meta/solutions/[^/]*\\.rb",
   "exercises": [
     {
       "slug": "hello-world",

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/exercism/xruby",
   "active": true,
   "gitter": "xruby",
-  "solutionpattern": "[Ee]xample|\\.meta/solutions/[^/]*\\.rb",
+  "solution_pattern": "[Ee]xample|\\.meta/solutions/[^/]*\\.rb",
   "exercises": [
     {
       "slug": "hello-world",


### PR DESCRIPTION
When https://github.com/exercism/configlet/pull/13 is merged, configlet will support alternate patterns for specifying the example solution filename.

This is done via the "solutionpattern" key.

The value `"\\.meta/solutions/[^/]*\\.rb"` ensures there is a `.rb` file in the `.meta/solutions` directory for a problem.
(double backslashes are required due to JSON escaping.)

It's not critical to check the exact name of the file, just that there is at least one ruby file which we can assume is a valid solution file. (Otherwise PR reviewers are being too slack.)

Merging this early should have no negative effects to the current version of configlet, but does risk (very small chance) there being other incompatible changes to configlet before this PR is merged.

Oh, and it requires synchronisation with the move of the example files.
(This might make it more appropriate that this PR be merged with that one. #607 )
