### PR TITLE
tests: Check in the correct location for the example file.

### DIFF
--- a/lib/tasks/exercise.rb
+++ b/lib/tasks/exercise.rb
@@ -23,7 +23,7 @@ class Exercise
   end
 
   def example_file
-    File.exist?(example_filename) ? example_filename : legacy_example_filename
+    File.exist?(File.join(directory, example_filename)) ? example_filename : legacy_example_filename
   end
 
   def testable_example_file

--- a/test/tasks/exercise_test.rb
+++ b/test/tasks/exercise_test.rb
@@ -31,8 +31,10 @@ class ExerciseTest < Minitest::Test
   end
 
   def test_example_file
-    File.stub(:exist?, true) do
-      assert_equal '.meta/solutions/name.rb', Exercise.new('name').example_file
+    mock_exist = Minitest::Mock.new
+    mock_exist.expect(:call, true, ['exercises/alpha/./.meta/solutions/alpha.rb'])
+    File.stub(:exist?, mock_exist) do
+      assert_equal '.meta/solutions/alpha.rb', Exercise.new('alpha').example_file
     end
   end
 


### PR DESCRIPTION
Fixes bug introduced in #605 which did not check in the right place for the existence of the example file when deciding which version of the example file to use.

The bug is fixed as part of #607 : https://github.com/exercism/xruby/pull/607/commits/1bca6eace6a1523c39aa51ae386b468792acffaf but this PR separates out the change and implements a unit test for it, verifying that the stubbed out `File.exist?` method is called with the correct filename.