### PR TITLE
generator: remove requirement for test case to know its index

### DIFF
--- a/exercises/alphametics/.meta/generator/test_template.erb
+++ b/exercises/alphametics/.meta/generator/test_template.erb
@@ -4,11 +4,11 @@ require_relative 'alphametics'
 
 # Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
 class AlphameticsTest < Minitest::Test
-<% test_cases.each do |test_case| %>
+<% test_cases.each_with_index do |test_case, idx| %>
 
 <%= test_case.runtime_comment %>
   def <%= test_case.name %>
-    <%= test_case.skipped %>
+    <%= test_case.skipped(idx) %>
     <%= test_case.workload %>
   end
 <% end %>

--- a/exercises/bowling/.meta/generator/test_template.erb
+++ b/exercises/bowling/.meta/generator/test_template.erb
@@ -12,9 +12,9 @@ class BowlingTest < Minitest::Test
     rolls.each { |pins| @game.roll(pins) }
   end
 
-<% test_cases.each do |test_case| %>
+<% test_cases.each_with_index do |test_case, idx| %>
   def <%= test_case.name %>
-    <%= test_case.skipped %>
+    <%= test_case.skipped(idx) %>
     <%= test_case.workload %>
   end
 

--- a/exercises/connect/.meta/generator/test_template.erb
+++ b/exercises/connect/.meta/generator/test_template.erb
@@ -4,9 +4,9 @@ require_relative 'connect'
 
 # Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
 class ConnectTest < Minitest::Test
-<% test_cases.each do |test_case| %>
+<% test_cases.each_with_index do |test_case, idx| %>
   <%= test_case.ignore_method_length%>def <%= test_case.name %>
-    <%= test_case.skipped %><% test_case.test_body.each do |line| %>
+    <%= test_case.skipped(idx) %><% test_case.test_body.each do |line| %>
     <%= line %><% end %>
   end
 

--- a/exercises/dominoes/.meta/generator/test_template.erb
+++ b/exercises/dominoes/.meta/generator/test_template.erb
@@ -4,9 +4,9 @@ require_relative 'dominoes'
 
 # Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
 class DominoesTest < Minitest::Test
-<% test_cases.each do |test_case| %>
+<% test_cases.each_with_index do |test_case, idx| %>
   def <%= test_case.name %>
-    <%= test_case.skipped %>
+    <%= test_case.skipped(idx) %>
     <%= test_case.workload %>
   end
 

--- a/exercises/hello-world/.meta/generator/test_template.erb
+++ b/exercises/hello-world/.meta/generator/test_template.erb
@@ -14,9 +14,9 @@ end
 
 # Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
 class HelloWorldTest < Minitest::Test
-<% test_cases.each do |test_case| %>
+<% test_cases.each_with_index do |test_case, idx| %>
   def <%= test_case.name %>
-    <%= test_case.skipped %>
+    <%= test_case.skipped(idx) %>
     <%= test_case.workload %>
   end
 <% end %>

--- a/exercises/leap/.meta/generator/test_template.erb
+++ b/exercises/leap/.meta/generator/test_template.erb
@@ -13,9 +13,9 @@ class Date
 end
 
 class YearTest < Minitest::Test
-<% test_cases.each do |test_case| %>
+<% test_cases.each_with_index do |test_case, idx| %>
   def <%= test_case.name %>
-    <%= test_case.skipped %>
+    <%= test_case.skipped(idx) %>
     <%= test_case.workload %>, "<%= test_case.failure_message %>"
   end
 

--- a/lib/generator/case_values.rb
+++ b/lib/generator/case_values.rb
@@ -6,11 +6,8 @@ module Generator
       end
 
       def cases(exercise_data)
-        extract_test_cases(
-          data: JSON.parse(exercise_data)['cases']
-        ).map.with_index do |test, index|
-          @case_class.new(test.merge('index' => index))
-        end
+        extract_test_cases(data: JSON.parse(exercise_data)['cases'])
+          .map { |test| @case_class.new(test) }
       end
 
       private

--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -10,12 +10,7 @@ module Generator
       'test_%s' % description.underscore
     end
 
-    # retain until converted
-    def skipped
-      index.zero? ? '# skip' : 'skip'
-    end
-
-    def skip(idx)
+    def skipped(idx)
       idx.zero? ? '# skip' : 'skip'
     end
 

--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -10,8 +10,13 @@ module Generator
       'test_%s' % description.underscore
     end
 
+    # retain until converted
     def skipped
       index.zero? ? '# skip' : 'skip'
+    end
+
+    def skip(idx)
+      idx.zero? ? '# skip' : 'skip'
     end
 
     protected

--- a/lib/generator/test_template.erb
+++ b/lib/generator/test_template.erb
@@ -4,9 +4,9 @@ require_relative '<%= exercise_name %>'
 
 # Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
 class <%= exercise_name_camel %>Test < Minitest::Test
-<% test_cases.each do |test_case| %>
+<% test_cases.each_with_index do |test_case, idx| %>
   def <%= test_case.name %>
-    <%= test_case.skipped %>
+    <%= test_case.skip(idx) %>
     <%= test_case.workload %>
   end
 

--- a/lib/generator/test_template.erb
+++ b/lib/generator/test_template.erb
@@ -6,7 +6,7 @@ require_relative '<%= exercise_name %>'
 class <%= exercise_name_camel %>Test < Minitest::Test
 <% test_cases.each_with_index do |test_case, idx| %>
   def <%= test_case.name %>
-    <%= test_case.skip(idx) %>
+    <%= test_case.skipped(idx) %>
     <%= test_case.workload %>
   end
 

--- a/test/fixtures/xruby/exercises/alpha/.meta/generator/alpha_cases.rb
+++ b/test/fixtures/xruby/exercises/alpha/.meta/generator/alpha_cases.rb
@@ -1,20 +1,9 @@
-class AlphaCase < OpenStruct
-
+class AlphaCase < Generator::ExerciseCase
   def name
     format('test_%s', description.downcase.gsub(/[ -]/, '_'))
   end
 
-  def assertion
-    expected ? 'assert' : 'refute'
-  end
-
-  def skip
-    index.zero? ? '# skip' : 'skip'
-  end
-end
-
-AlphaCases = proc do |data|
-  JSON.parse(data)['cases'].map.with_index do |row, i|
-    AlphaCase.new(row.merge('index' => i))
+  def workload
+    "assert true"
   end
 end

--- a/test/fixtures/xruby/exercises/alpha/.meta/generator/test_template.erb
+++ b/test/fixtures/xruby/exercises/alpha/.meta/generator/test_template.erb
@@ -6,9 +6,9 @@ require_relative '<%= exercise_name %>'
 
 # Common test data version: <%= abbreviated_commit_hash %>
 class <%= exercise_name_camel %>Test < Minitest::Test
-<% test_cases.each do |test_case| %>
+<% test_cases.each_with_index do |test_case, idx| %>
   def <%= test_case.name %>
-    <%= test_case.skipped %>
+    <%= test_case.skipped(idx) %>
     <%= test_case.workload %>
   end
 

--- a/test/fixtures/xruby/lib/generator/test_template.erb
+++ b/test/fixtures/xruby/lib/generator/test_template.erb
@@ -4,9 +4,9 @@ require_relative 'acronym'
 
 # Common test data version: <%= abbreviated_commit_hash %>
 class AcronymTest < Minitest::Test
-<% test_cases.each do |test_case| %>
+<% test_cases.each_with_index do |test_case, idx| %>
   def <%= test_case.name %>
-    <%= test_case.skipped %>
+    <%= test_case.skipped(idx) %>
     <%= test_case.workload %>
   end
 

--- a/test/generator/case_values_test.rb
+++ b/test/generator/case_values_test.rb
@@ -17,11 +17,11 @@ module Generator
 
         expected = [
           ComplexCase.new(description: 'first generic verse', property: 'verse', number: 99,
-                          expected: '99 bottles of beer on the wall, YAAAR', index: 0),
+                          expected: '99 bottles of beer on the wall, YAAAR'),
           ComplexCase.new(description: 'last generic verse', property: 'verse', number: 3,
-                          expected: '3 bottles of beer on the wall, YAAAR', index: 1),
+                          expected: '3 bottles of beer on the wall, YAAAR'),
           ComplexCase.new(description: 'first two verses', property: 'verses', beginning: 99, end: 98,
-                          expected: "99 bottles of beer on the wall, YAR, PIRATES CAN'T COUNT", index: 2)
+                          expected: "99 bottles of beer on the wall, YAR, PIRATES CAN'T COUNT")
         ]
         assert_equal expected, cases
       end

--- a/test/generator/exercise_case_test.rb
+++ b/test/generator/exercise_case_test.rb
@@ -6,12 +6,12 @@ module Generator
       assert_equal 'test_foo', ExerciseCase.new(description: 'foo').name
     end
 
-    def test_skipped_index_zero
-      assert_equal '# skip', ExerciseCase.new(index: 0).skipped
+    def test_skip_index_zero
+      assert_equal '# skip', ExerciseCase.new.skip(0)
     end
 
-    def test_skipped_index_nonzero
-      assert_equal 'skip', ExerciseCase.new(index: 12).skipped
+    def test_skip_index_nonzero
+      assert_equal 'skip', ExerciseCase.new.skip(1)
     end
 
     class MultiLineCase < ExerciseCase

--- a/test/generator/exercise_case_test.rb
+++ b/test/generator/exercise_case_test.rb
@@ -6,12 +6,12 @@ module Generator
       assert_equal 'test_foo', ExerciseCase.new(description: 'foo').name
     end
 
-    def test_skip_index_zero
-      assert_equal '# skip', ExerciseCase.new.skip(0)
+    def test_skipped_index_zero
+      assert_equal '# skip', ExerciseCase.new.skipped(0)
     end
 
-    def test_skip_index_nonzero
-      assert_equal 'skip', ExerciseCase.new.skip(1)
+    def test_skipped_index_nonzero
+      assert_equal 'skip', ExerciseCase.new.skipped(1)
     end
 
     class MultiLineCase < ExerciseCase

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -106,7 +106,6 @@ module Generator
       subject = TestTemplateValuesFactory.new
       assert_instance_of TemplateValues, subject.template_values
       assert Object.const_defined?(:AlphaCase)
-      assert Object.const_defined?(:AlphaCases)
     end
 
     def teardown


### PR DESCRIPTION
Part of the Generator Improvements: exercism/xruby#485

Changes:
* Convert the default `test_template.erb` to include the index in the iterator (with test changes, etc)
* Update the six custom test templates in the same way
* Stop injecting index as a case value
* (and cleaned up a fixture/test that was leftover from the cases proc logic)

Testing:
* `rake test`
* regenerated test suites for all six exercises with custom test templates, no changes
* regenerated test suites for a sample of other exercises, no changes