### PR TITLE
robot-name: Updated based on clarified description.

### DIFF
--- a/config.json
+++ b/config.json
@@ -61,12 +61,6 @@
       ]
     },
     {
-      "slug": "robot-name",
-      "difficulty": 1,
-      "topics": [
-      ]
-    },
-    {
       "slug": "nth-prime",
       "difficulty": 1,
       "topics": [
@@ -255,6 +249,12 @@
     {
       "slug": "meetup",
       "difficulty": 1,
+      "topics": [
+      ]
+    },
+    {
+      "slug": "robot-name",
+      "difficulty": 6,
       "topics": [
       ]
     },

--- a/exercises/robot-name/.meta/solutions/robot-name.rb
+++ b/exercises/robot-name/.meta/solutions/robot-name.rb
@@ -1,43 +1,21 @@
-module BookKeeping
-  VERSION = 2
-end
-
 class Robot
-  @taken_names = {}
+  def self.forget
+    @@name_enumerator = [*'AA000'..'ZZ999'].shuffle.each
+  end
 
-  def name
-    @name ||= generate_name
+  self.forget
+
+  attr_reader :name
+
+  def initialize
+    reset
   end
 
   def reset
-    @name = nil
+    @name = @@name_enumerator.next
   end
+end
 
-  def self.taken_names
-    @taken_names
-  end
-
-  private
-
-  def generate_name
-    name = "#{prefix}#{suffix}"
-    if self.class.taken_names[name]
-      generate_name
-    else
-      self.class.taken_names[name] = true
-      name
-    end
-  end
-
-  def prefix
-    alphabet.sample(2).join('')
-  end
-
-  def suffix
-    rand(100...999)
-  end
-
-  def alphabet
-    ('A'..'Z').to_a
-  end
+module BookKeeping
+  VERSION = 3
 end

--- a/exercises/robot-name/HINTS.md
+++ b/exercises/robot-name/HINTS.md
@@ -1,0 +1,7 @@
+
+In order to make this easier to test, your solution will need to implement a
+`Robot.forget` method that clears any shared state that might exist to track
+duplicate robot names.
+
+Bonus points if this method does not need to do anything for your solution.
+

--- a/exercises/robot-name/robot_name_test.rb
+++ b/exercises/robot-name/robot_name_test.rb
@@ -50,8 +50,9 @@ class RobotTest < Minitest::Test
       robot.reset
       names << robot.name
     end
-    # This will probably be 5, but only accross multiple robots is uniqueness a requirement.
-    assert names.uniq.size > 2
+    # This will probably be 5, but name uniqueness is only a requirement
+    # accross multiple robots and consecutive calls to reset.
+    assert names.uniq.size > 1
   end
 
   def test_different_robots_have_different_names

--- a/exercises/robot-name/robot_name_test.rb
+++ b/exercises/robot-name/robot_name_test.rb
@@ -1,60 +1,95 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: false
 
 require 'minitest/autorun'
 require_relative 'robot_name'
 
 class RobotTest < Minitest::Test
-  DIFFERENT_ROBOT_NAME_SEED = 1234
-  SAME_INITIAL_ROBOT_NAME_SEED = 1000
-
-  COMMAND_QUERY = <<-MSG.freeze
-    Command/Query Separation:
-    Query methods should generally not change object state.
-  MSG
-
   NAME_REGEXP = /^[A-Z]{2}\d{3}$/
 
+  def setup
+    Robot.forget
+  end
+
+  def test_can_create_a_robot
+    skip
+    refute_nil Robot.new
+  end
+
   def test_has_name
+    skip
     assert_match NAME_REGEXP, Robot.new.name
   end
 
   def test_name_sticks
     skip
     robot = Robot.new
-    robot.name
-    assert_equal robot.name, robot.name
+    original_name = robot.name
+    assert_equal original_name, robot.name
+  end
+
+  def test_reset_changes_name
+    skip
+    robot = Robot.new
+    original_name = robot.name
+    robot.reset
+    refute_equal original_name, robot.name
+  end
+
+  def test_reset_before_name_called_does_not_cause_an_error
+    skip
+    robot = Robot.new
+    robot.reset
+    assert_match NAME_REGEXP, Robot.new.name
+  end
+
+  def test_reset_multiple_times
+    skip
+    robot = Robot.new
+    names = []
+    5.times do
+      robot.reset
+      names << robot.name
+    end
+    # This will probably be 5, but only accross multiple robots is uniqueness a requirement.
+    assert names.uniq.size > 2
   end
 
   def test_different_robots_have_different_names
     skip
-    Kernel.srand DIFFERENT_ROBOT_NAME_SEED
     refute_equal Robot.new.name, Robot.new.name
   end
 
-  def test_reset_name
-    skip
-    Kernel.srand DIFFERENT_ROBOT_NAME_SEED
-    robot = Robot.new
-    name = robot.name
-    robot.reset
-    name2 = robot.name
-    refute_equal name, name2
-    assert_equal name2, robot.name, COMMAND_QUERY
-    assert_match NAME_REGEXP, name2
-  end
-
+  # This test assumes you're using Kernel.rand as a source of randomness
   def test_different_name_when_chosen_name_is_taken
     skip
-    Kernel.srand SAME_INITIAL_ROBOT_NAME_SEED
-    name1 = Robot.new.name
-    Kernel.srand SAME_INITIAL_ROBOT_NAME_SEED
-    name2 = Robot.new.name
-    refute_equal name1, name2
+    same_seed = 1234
+    Kernel.srand same_seed
+    robot_1 = Robot.new
+    name_1  = robot_1.name
+    Kernel.srand same_seed
+    robot_2 = Robot.new
+    name_2 = robot_2.name
+    refute_equal name_1, name_2
+  end
+
+  def test_generate_all_robots
+    skip
+    all_names_count = 26 * 26 * 1000
+    time_limit = Time.now + 60 # seconds
+    seen_names = Hash.new(0)
+    robots = []
+    while seen_names.size < all_names_count && Time.now < time_limit
+      robot = Robot.new
+      seen_names[robot.name] += 1
+      robots << robot
+    end
+    timeout_message = "Timed out trying to generate all possible robots"
+    assert_equal all_names_count, robots.size, timeout_message
+    assert seen_names.values.all? { |count| count == 1 }, "Some names used more than once"
+    assert seen_names.keys.all? { |name| name.match(NAME_REGEXP) }, "Not all names match #{NAME_REGEXP}"
   end
 
   def test_version
-    skip
-    assert_equal 2, BookKeeping::VERSION
+    assert_equal 3, BookKeeping::VERSION
   end
 end


### PR DESCRIPTION
The robot name description [has been updated](https://github.com/exercism/x-common/pull/765)  to clarify that name uniqueness is a requirement.

> The names must be random: they should not follow a predictable sequence.
Random names means a risk of collisions. Your solution must ensure that
every existing robot has a unique name.

This PR updates the tests and example solution to match this.

Because the new problem is significantly harder than the old version it has been moved down in the order of problems.
 
A HINTS.md file has been added to specify the `forget` method used to aid in testing.



