### PR TITLE
[WIP] Refactor exercise case

### DIFF
--- a/exercises/wordy/.meta/generator/wordy_cases.rb
+++ b/exercises/wordy/.meta/generator/wordy_cases.rb
@@ -4,7 +4,7 @@ class WordyCase < Generator::ExerciseCase
 
   def workload
     [
-      "question = '#{input}'",
+      "question = '#{case_data['input']}'",
       indent(4, assertion),
     ].join("\n")
   end
@@ -16,10 +16,10 @@ class WordyCase < Generator::ExerciseCase
   end
 
   def assertion
-    return error_assertion unless expected
+    return error_assertion unless case_data['expected']
     return message_assertion if message
 
-    "assert_equal(#{expected}, WordProblem.new(question).answer)"
+    "assert_equal(#{case_data['expected']}, WordProblem.new(question).answer)"
   end
 
   def error_assertion
@@ -34,12 +34,12 @@ class WordyCase < Generator::ExerciseCase
     [
       'answer = WordProblem.new(question).answer',
       "message = \"#{message % '#{answer}'}\"",
-      "assert_equal(#{expected}, answer, message)",
+      "assert_equal(#{case_data['expected']}, answer, message)",
     ].join("\n")
   end
 
   def message
-    return unless input == 'What is -3 plus 7 multiplied by -2?'
+    return unless case_data['input'] == 'What is -3 plus 7 multiplied by -2?'
 
     'You should ignore order of precedence. -3 + 7 * -2 = -8, not %s'
   end

--- a/lib/generator/case_values.rb
+++ b/lib/generator/case_values.rb
@@ -7,7 +7,7 @@ module Generator
 
       def cases(exercise_data)
         extract_test_cases(data: JSON.parse(exercise_data)['cases'])
-          .map { |test| @case_class.new(test) }
+          .map { |test| @case_class.new(case_data: test) }
       end
 
       private

--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -1,50 +1,22 @@
 require 'ostruct'
 
 module Generator
-  class ExerciseCase < OpenStruct
+  class ExerciseCase
     using Generator::Underscore
+    include CaseHelpers
     include Assertion
 
+    attr_reader :case_data
+    def initialize(case_data:)
+      @case_data = case_data
+    end
+
     def name
-      'test_%s' % description.underscore
+      'test_%s' % case_data['description'].underscore
     end
 
-    def skipped(idx)
-      idx.zero? ? '# skip' : 'skip'
-    end
-
-    protected
-
-    # indent multi line workloads
-    #
-    #   indent_lines(
-    #     [
-    #       "string = #{input.inspect}",
-    #       "#{assert} Isogram.is_isogram?(string)"
-    #     ], 4
-    #   )
-    def indent_lines(code, depth, separator = "\n")
-      code.join(separator + ' ' * depth)
-    end
-
-    # indent multi line workloads with (unindented) blank lines
-    #
-    #   indent_text(4, text)
-    def indent_text(depth, text)
-      text.lines.reduce do |obj, line|
-        obj << (line == "\n" ? line : ' ' * depth + line)
-      end
-    end
-
-    # generate heredoc (as part of workload) with optional indentation
-    #
-    #    indent_heredoc(["foo", "bar"], 'TEXT', 1)
-    def indent_heredoc(lines, delimiter, depth = 0, delimiter_method = nil)
-      [
-        "<<-#{delimiter}#{delimiter_method}",
-        lines.map { |line| ' ' * depth + line }.join("\n"),
-        delimiter
-      ].join("\n")
+    def skipped(index)
+      index.zero? ? '# skip' : 'skip'
     end
   end
 end

--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -1,5 +1,4 @@
 require 'ostruct'
-require 'json'
 
 module Generator
   class ExerciseCase < OpenStruct

--- a/lib/generator/exercise_case/assertion.rb
+++ b/lib/generator/exercise_case/assertion.rb
@@ -1,31 +1,59 @@
 module Generator
-  class ExerciseCase < OpenStruct
+  class ExerciseCase
     module Assertion
 
+      # generates assertions of the form
+      #
+      #   assert whatever
+      #   refute whatever
+      #
+      # depending on whether 'expected' is true or false
+      #
+      # call as
+      #
       #  "#{assert} Luhn.valid?(#{input.inspect})"
+      #
       def assert
-        expected ? 'assert' : 'refute'
+        case_data['expected'] ? 'assert' : 'refute'
       end
 
-      # e.g.,
+      # generates assertions of the form
+      #
+      #   assert_nil whatever
+      #   assert_equal expected, whatever
+      #
+      # depending on whether 'expected' is nil or not
+      #
+      # call as
+      #
       #   assert_equal { "PigLatin.translate(#{input.inspect})" }
+      #
       def assert_equal
-        assertion = expected.nil? ? 'assert_nil' : "assert_equal #{expected.inspect},"
+        assertion = case_data['expected'].nil? ? 'assert_nil' :
+                      "assert_equal #{case_data['expected'].inspect},"
         "#{assertion} #{yield}"
       end
 
-      # e.g.,
+      # a helper function, used to build statements such as
+      #
       #   if raises_error?
       #     assert_raises(ArgumentError) { test_case }
       #   else
       #     assert_equal { test_case }
       #   end
+      #
       def raises_error?
-        expected.to_i == -1
+        case_data['expected'].to_i == -1
       end
 
-      # e.g.,
+      # generates assertions of the form
+      #
+      #   assert_raises(SomeError) { whatever }
+      #
+      # call as
+      #
       #   assert_raises(ArgumentError) { test_case }
+      #
       def assert_raises(error)
         "assert_raises(#{error}) { #{yield} }"
       end

--- a/lib/generator/exercise_case/case_helpers.rb
+++ b/lib/generator/exercise_case/case_helpers.rb
@@ -1,0 +1,39 @@
+module Generator
+  class ExerciseCase
+    module CaseHelpers
+      protected
+
+      # indent multi line workloads
+      #
+      #   indent_lines(
+      #     [
+      #       "string = #{input.inspect}",
+      #       "#{assert} Isogram.is_isogram?(string)"
+      #     ], 4
+      #   )
+      def indent_lines(code, depth, separator = "\n")
+        code.join(separator + ' ' * depth)
+      end
+
+      # indent multi line workloads with (unindented) blank lines
+      #
+      #   indent_text(4, text)
+      def indent_text(depth, text)
+        text.lines.reduce do |obj, line|
+          obj << (line == "\n" ? line : ' ' * depth + line)
+        end
+      end
+
+      # generate heredoc (as part of workload) with optional indentation
+      #
+      #    indent_heredoc(["foo", "bar"], 'TEXT', 1)
+      def indent_heredoc(lines, delimiter, depth = 0, delimiter_method = nil)
+        [
+          "<<-#{delimiter}#{delimiter_method}",
+          lines.map { |line| ' ' * depth + line }.join("\n"),
+          delimiter
+        ].join("\n")
+      end
+    end
+  end
+end

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Generator
   # Contains methods accessible to the ERB template
   class TemplateValues

--- a/test/generator/case_values_test.rb
+++ b/test/generator/case_values_test.rb
@@ -16,14 +16,35 @@ module Generator
         ).cases(canonical_data)
 
         expected = [
-          ComplexCase.new(description: 'first generic verse', property: 'verse', number: 99,
-                          expected: '99 bottles of beer on the wall, YAAAR'),
-          ComplexCase.new(description: 'last generic verse', property: 'verse', number: 3,
-                          expected: '3 bottles of beer on the wall, YAAAR'),
-          ComplexCase.new(description: 'first two verses', property: 'verses', beginning: 99, end: 98,
-                          expected: "99 bottles of beer on the wall, YAR, PIRATES CAN'T COUNT")
+          ComplexCase.new(
+            case_data: {
+              'description' => 'first generic verse',
+              'property' => 'verse',
+              'number' => 99,
+              'expected' => '99 bottles of beer on the wall, YAAAR'
+            }
+          ),
+          ComplexCase.new(
+            case_data: {
+              'description' => 'last generic verse',
+              'property' => 'verse',
+              'number' => 3,
+              'expected' => '3 bottles of beer on the wall, YAAAR'
+            }
+          ),
+          ComplexCase.new(
+            case_data: {
+              'description' => 'first two verses',
+              'property' => 'verses',
+              'beginning' => 99,
+              'end' => 98,
+              'expected' => "99 bottles of beer on the wall, YAR, PIRATES CAN'T COUNT"
+            }
+          )
         ]
-        assert_equal expected, cases
+        assert expected.zip(cases).all? do |exp, cs|
+          assert_equal exp.case_data, cs.case_data
+        end
       end
     end
   end

--- a/test/generator/exercise_case/assertion_test.rb
+++ b/test/generator/exercise_case/assertion_test.rb
@@ -4,43 +4,43 @@ module Generator
   class ExerciseCase
     class AssertionTest < Minitest::Test
       def test_assert
-        test_case = OpenStruct.new(expected: true)
+        test_case = OpenStruct.new(case_data: {'expected' => true})
         test_case.extend(Assertion)
         assert_equal 'assert', test_case.assert
       end
 
       def test_refute
-        test_case = OpenStruct.new(expected: false)
+        test_case = OpenStruct.new(case_data: {'expected' => false})
         test_case.extend(Assertion)
         assert_equal 'refute', test_case.assert
       end
 
       def test_assert_equal
-        test_case = OpenStruct.new(expected: 2)
+        test_case = OpenStruct.new(case_data: {'expected' => 2})
         test_case.extend(Assertion)
         assert_equal "assert_equal 2, 4", test_case.assert_equal { 1 + 3 }
       end
 
       def test_assert_equal_when_nil
-        test_case = OpenStruct.new(expected: nil)
+        test_case = OpenStruct.new(case_data: {'expected' => nil})
         test_case.extend(Assertion)
         assert_equal "assert_nil 4", test_case.assert_equal { 1 + 3 }
       end
 
       def test_raises_error
-        test_case = OpenStruct.new(expected: -1)
+        test_case = OpenStruct.new(case_data: {'expected' => -1})
         test_case.extend(Assertion)
         assert test_case.raises_error?
       end
 
       def test_does_not_raise_error
-        test_case = OpenStruct.new(expected: 'cute kitties')
+        test_case = OpenStruct.new(case_data: {'expected' => 'cute kitties'})
         test_case.extend(Assertion)
         refute test_case.raises_error?
       end
 
       def test_assert_raises
-        test_case = OpenStruct.new
+        test_case = OpenStruct.new(case_data: {})
         test_case.extend(Assertion)
         assert_equal(
           "assert_raises(ArgumentError) { 4 }",

--- a/test/generator/exercise_case/case_helpers_test.rb
+++ b/test/generator/exercise_case/case_helpers_test.rb
@@ -1,0 +1,43 @@
+require_relative '../../test_helper'
+
+module Generator
+  class ExerciseCase
+    class CaseHelpersTest < Minitest::Test
+      class MultiLineCase
+        include CaseHelpers
+
+        def workload
+          indent_lines(['foo', 'bar'], 1)
+        end
+      end
+      def test_indent_multiline_workloads
+        expected = "foo\n bar"
+        assert_equal expected, MultiLineCase.new.workload
+      end
+
+      class BlankLineCase
+        include CaseHelpers
+
+        def workload
+          indent_text(2, "foo\n\nbar\n")
+        end
+      end
+      def test_indent_multiline_workloads_with_blank_lines
+        expected = "foo\n\n  bar\n"
+        assert_equal expected, BlankLineCase.new.workload
+      end
+
+      class HeredocCase
+        include CaseHelpers
+
+        def workload
+          indent_heredoc(["foo", "bar"], 'TEXT', 1)
+        end
+      end
+      def test_heredoc
+        expected = "<<-TEXT\n foo\n bar\nTEXT"
+        assert_equal expected, HeredocCase.new.workload
+      end
+    end
+  end
+end

--- a/test/generator/exercise_case_test.rb
+++ b/test/generator/exercise_case_test.rb
@@ -3,45 +3,15 @@ require_relative '../test_helper'
 module Generator
   class ExerciseCaseTest < Minitest::Test
     def test_name
-      assert_equal 'test_foo', ExerciseCase.new(description: 'foo').name
+      assert_equal 'test_foo', ExerciseCase.new(case_data: {'description' => 'foo'}).name
     end
 
     def test_skipped_index_zero
-      assert_equal '# skip', ExerciseCase.new.skipped(0)
+      assert_equal '# skip', ExerciseCase.new(case_data: {}).skipped(0)
     end
 
     def test_skipped_index_nonzero
-      assert_equal 'skip', ExerciseCase.new.skipped(1)
-    end
-
-    class MultiLineCase < ExerciseCase
-      def workload
-        indent_lines(['foo', 'bar'], 1)
-      end
-    end
-    def test_indent_multiline_workloads
-      expected = "foo\n bar"
-      assert_equal expected, MultiLineCase.new.workload
-    end
-
-    class BlankLineCase < ExerciseCase
-      def workload
-        indent_text(2, "foo\n\nbar\n")
-      end
-    end
-    def test_indent_multiline_workloads_with_blank_lines
-      expected = "foo\n\n  bar\n"
-      assert_equal expected, BlankLineCase.new.workload
-    end
-
-    class HeredocCase < ExerciseCase
-      def workload
-        indent_heredoc(["foo", "bar"], 'TEXT', 1)
-      end
-    end
-    def test_heredoc
-      expected = "<<-TEXT\n foo\n bar\nTEXT"
-      assert_equal expected, HeredocCase.new.workload
+      assert_equal 'skip', ExerciseCase.new(case_data: {}).skipped(1)
     end
   end
 end

--- a/test/wordy_cases_test.rb
+++ b/test/wordy_cases_test.rb
@@ -4,7 +4,7 @@ require_relative '../exercises/wordy/.meta/generator/wordy_cases'
 
 class WordyCaseTest < Minitest::Test
   def test_workload_with_expected_and_no_message
-    test_case = WordyCase.new(expected: 1, input: 1)
+    test_case = WordyCase.new(case_data: {'expected' => 1, 'input' => 1})
 
     expected_workload = [
       'question = \'1\'',
@@ -15,7 +15,9 @@ class WordyCaseTest < Minitest::Test
   end
 
   def test_workload_with_expected_and_message
-    test_case = WordyCase.new(expected: 1, input: 'What is -3 plus 7 multiplied by -2?')
+    test_case = WordyCase.new(
+      case_data: {'expected' => 1, 'input' => 'What is -3 plus 7 multiplied by -2?'}
+    )
     message = test_case.send(:message)
 
     expected_workload = [
@@ -29,7 +31,7 @@ class WordyCaseTest < Minitest::Test
   end
 
   def test_workload_without_expected
-    test_case = WordyCase.new(input: 1)
+    test_case = WordyCase.new(case_data: {'input' => 1})
 
     expected_workload = [
       'question = \'1\'',


### PR DESCRIPTION
A first pass at "ExerciseCase should not be an OpenStruct and the canonical data should be kept separate from the methods of this class." from Generator Improvements exercism/xruby#485.

* ExerciseCase is no longer an OpenStruct
* canonical data is injected into an ExerciseCase as case_data

More changes need to be made, in the various *_cases.rb. Identifying what changes need to be made will be simple once exercism/xruby#620 is merged 😄 

Todo:
* rebase onto master
* run `bin/generate --all` to figure out what else needs to be updated and update
* for bonus points, use an OpenStruct rather than a hash for the data
* for bonus points, write tests to catch what got caught by running `bin/generate --all` in this case