### PR TITLE
generator: refactor generate cases

### DIFF
--- a/lib/generator/files/generator_cases.rb
+++ b/lib/generator/files/generator_cases.rb
@@ -10,16 +10,10 @@ module Generator
           filename(exercise_name_or_slug).split('_').map(&:capitalize).join
         end
 
-        def source_filepath(track_path, slug)
-          path = meta_generator_path(track_path, slug)
-          filename = filename(slug) + '.rb'
-          File.join(path, filename)
-        end
-
         private
 
         def cases_filepaths(track_path)
-          generator_glob = File.join(meta_generator_path(track_path, '*'), '*_case.rb')
+          generator_glob = File.join(track_path, 'exercises', '*', '.meta', 'generator', '*_case.rb')
           Dir.glob(generator_glob, File::FNM_DOTMATCH)
         end
 
@@ -29,10 +23,6 @@ module Generator
 
         def filename(exercise_name_or_slug)
           "#{exercise_name_or_slug.tr('-', '_')}_case"
-        end
-
-        def meta_generator_path(track_path, slug)
-          File.join(track_path, 'exercises', slug, '.meta', 'generator')
         end
       end
     end

--- a/lib/generator/files/generator_cases.rb
+++ b/lib/generator/files/generator_cases.rb
@@ -6,10 +6,6 @@ module Generator
           cases_filepaths(track_path).map { |filepath| slugify(filepath) }.sort
         end
 
-        def class_name(exercise_name_or_slug)
-          filename(exercise_name_or_slug).split('_').map(&:capitalize).join
-        end
-
         private
 
         def cases_filepaths(track_path)
@@ -18,11 +14,7 @@ module Generator
         end
 
         def slugify(filepath)
-          %r{([^/]*)_case\.rb$}.match(filepath).captures[0].tr('_', '-')
-        end
-
-        def filename(exercise_name_or_slug)
-          "#{exercise_name_or_slug.tr('-', '_')}_case"
+          File.basename(filepath, '_case.rb').tr('_', '-')
         end
       end
     end

--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -56,7 +56,7 @@ module Generator
       end
 
       def cases_filename
-        "#{exercise_name}_case.rb"
+        "#{test_case_name}.rb"
       end
 
       def tests_template_absolute_filename

--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -17,8 +17,8 @@ module Generator
         ExampleSolutionFile.new(filename: File.join(solutions_path, example_filename))
       end
 
-      def cases_filepath
-        CasesFile.new(filename: File.join(generator_path, cases_filename))
+      def case_filepath
+        CaseFile.new(filename: File.join(generator_path, case_filename))
       end
 
       def tests_template
@@ -55,7 +55,7 @@ module Generator
         "#{exercise_name}.rb"
       end
 
-      def cases_filename
+      def case_filename
         "#{test_case_name}.rb"
       end
 
@@ -104,6 +104,6 @@ module Generator
     class TestsTemplateFile < Readable
     end
 
-    class CasesFile < Readable; end
+    class CaseFile < Readable; end
   end
 end

--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -17,6 +17,10 @@ module Generator
         ExampleSolutionFile.new(filename: File.join(solutions_path, example_filename))
       end
 
+      def cases_filepath
+        CasesFile.new(filename: File.join(generator_path, cases_filename))
+      end
+
       def tests_template
         TestsTemplateFile.new(filename: tests_template_absolute_filename)
       end
@@ -35,6 +39,10 @@ module Generator
         File.join(meta_path, 'solutions')
       end
 
+      def generator_path
+        File.join(meta_path, 'generator')
+      end
+
       def minitest_tests_filename
         "#{exercise_name}_test.rb"
       end
@@ -45,6 +53,10 @@ module Generator
 
       def example_filename
         "#{exercise_name}.rb"
+      end
+
+      def cases_filename
+        "#{exercise_name}_cases.rb"
       end
 
       def tests_template_absolute_filename
@@ -91,5 +103,7 @@ module Generator
 
     class TestsTemplateFile < Readable
     end
+
+    class CasesFile < Readable; end
   end
 end

--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -56,7 +56,7 @@ module Generator
       end
 
       def cases_filename
-        "#{exercise_name}_cases.rb"
+        "#{exercise_name}_case.rb"
       end
 
       def tests_template_absolute_filename

--- a/lib/generator/repository.rb
+++ b/lib/generator/repository.rb
@@ -35,6 +35,10 @@ module Generator
     def exercise_name
       @exercise_name ||= slug.tr('-', '_')
     end
+
+    def test_case_name
+      exercise_name + '_case'
+    end
   end
 
   # This exists to give us a clue as to what we are delegating to.

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -38,7 +38,7 @@ module Generator
     end
 
     def extract
-      load cases_load_name
+      load case_load_name
       extractor.cases(canonical_data.to_s)
     end
 
@@ -52,8 +52,8 @@ module Generator
       test_case_name.split('_').map(&:capitalize).join
     end
 
-    def cases_load_name
-      cases_filepath.filename
+    def case_load_name
+      case_filepath.filename
     end
   end
 end

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -49,7 +49,7 @@ module Generator
     end
 
     def cases_load_name
-      Files::GeneratorCases.source_filepath(paths.track, slug)
+      cases_filepath.filename
     end
   end
 end

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -44,8 +44,12 @@ module Generator
 
     def extractor
         CaseValues::Extractor.new(
-          case_class: Object.const_get(Files::GeneratorCases.class_name(slug))
+          case_class: Object.const_get(case_class_name)
         )
+    end
+
+    def case_class_name
+      test_case_name.split('_').map(&:capitalize).join
     end
 
     def cases_load_name

--- a/sed
+++ b/sed
@@ -1,1 +1,0 @@
-foo_cases s/cases/case/g

--- a/test/generator/files/generate_cases_test.rb
+++ b/test/generator/files/generate_cases_test.rb
@@ -21,10 +21,6 @@ module Generator
         end
         mock_glob_call.verify
       end
-
-      def test_class_name
-        assert_equal 'TwoParterCase', GeneratorCases.class_name('two-parter')
-      end
     end
   end
 end

--- a/test/generator/files/generate_cases_test.rb
+++ b/test/generator/files/generate_cases_test.rb
@@ -25,13 +25,6 @@ module Generator
       def test_class_name
         assert_equal 'TwoParterCase', GeneratorCases.class_name('two-parter')
       end
-
-      def test_source_filepath
-        track_path = '/track'
-        slug = 'slug'
-        expected_filename = track_path + '/exercises/slug/.meta/generator/slug_case.rb'
-        assert_equal expected_filename, GeneratorCases.source_filepath(track_path, slug)
-      end
     end
   end
 end

--- a/test/generator/files/track_files_test.rb
+++ b/test/generator/files/track_files_test.rb
@@ -13,8 +13,9 @@ module Generator
           @paths = FixturePaths
           @slug = 'alpha-beta'
           @exercise_name = 'alpha_beta'
+          @test_case_name = 'alpha_beta_case'
         end
-        attr_accessor :paths, :slug, :exercise_name
+        attr_accessor :paths, :slug, :exercise_name, :test_case_name
         include TrackFiles
       end
 

--- a/test/generator/files/track_files_test.rb
+++ b/test/generator/files/track_files_test.rb
@@ -34,6 +34,12 @@ module Generator
         assert_instance_of MinitestTestsFile, subject.minitest_tests
       end
 
+      def test_cases_filepath
+        subject = TestTrackFiles.new
+        expected_filepath = FixturePaths.track + '/exercises/alpha-beta/.meta/generator/alpha_beta_cases.rb'
+        assert_equal expected_filepath, subject.cases_filepath.filename
+      end
+
       def test_tests_template
         subject = TestTrackFiles.new
         expected_filename = FixturePaths.track + '/exercises/alpha-beta/.meta/generator/test_template.erb'

--- a/test/generator/files/track_files_test.rb
+++ b/test/generator/files/track_files_test.rb
@@ -35,10 +35,10 @@ module Generator
         assert_instance_of MinitestTestsFile, subject.minitest_tests
       end
 
-      def test_cases_filepath
+      def test_case_filepath
         subject = TestTrackFiles.new
         expected_filepath = FixturePaths.track + '/exercises/alpha-beta/.meta/generator/alpha_beta_case.rb'
-        assert_equal expected_filepath, subject.cases_filepath.filename
+        assert_equal expected_filepath, subject.case_filepath.filename
       end
 
       def test_tests_template

--- a/test/generator/files/track_files_test.rb
+++ b/test/generator/files/track_files_test.rb
@@ -36,7 +36,7 @@ module Generator
 
       def test_cases_filepath
         subject = TestTrackFiles.new
-        expected_filepath = FixturePaths.track + '/exercises/alpha-beta/.meta/generator/alpha_beta_cases.rb'
+        expected_filepath = FixturePaths.track + '/exercises/alpha-beta/.meta/generator/alpha_beta_case.rb'
         assert_equal expected_filepath, subject.cases_filepath.filename
       end
 

--- a/test/generator/repository_test.rb
+++ b/test/generator/repository_test.rb
@@ -49,6 +49,11 @@ module Generator
       subject = Repository.new(paths: FixturePaths, slug: 'alpha-beta')
       assert_equal 'alpha_beta', subject.exercise_name
     end
+
+    def test_test_case_name
+      subject = Repository.new(paths: FixturePaths, slug: 'two-parter')
+      assert_equal 'two_parter_case', subject.test_case_name
+    end
   end
 
   class LoggingRepositoryTest < Minitest::Test

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -87,14 +87,14 @@ module Generator
 
     def test_template_values_from_class
       subject = ClassBasedTestTemplateValuesFactory.new
-      subject.stub(:cases_load_name, 'test/fixtures/xruby/exercises/beta/.meta/generator/beta_case.rb') do
+      subject.stub(:case_load_name, 'test/fixtures/xruby/exercises/beta/.meta/generator/beta_case.rb') do
         assert_instance_of TemplateValues, subject.template_values
       end
     end
 
     def test_template_values_loads_problem_case_classes
       subject = TestTemplateValuesFactory.new
-      subject.stub(:cases_load_name, 'test/fixtures/xruby/exercises/alpha/.meta/generator/alpha_case.rb') do
+      subject.stub(:case_load_name, 'test/fixtures/xruby/exercises/alpha/.meta/generator/alpha_case.rb') do
         assert_instance_of TemplateValues, subject.template_values
         assert Object.const_defined?(:AlphaCase)
       end

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -50,6 +50,10 @@ module Generator
         'alpha'
       end
 
+      def test_case_name
+        'alpha_case'
+      end
+
       def version
         2
       end
@@ -74,6 +78,10 @@ module Generator
     class ClassBasedTestTemplateValuesFactory < TestTemplateValuesFactory
       def slug
         'beta'
+      end
+
+      def test_case_name
+        'beta_case'
       end
     end
 

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -79,14 +79,14 @@ module Generator
 
     def test_template_values_from_class
       subject = ClassBasedTestTemplateValuesFactory.new
-      subject.stub(:cases_load_name, 'test/fixtures/xruby/exercises/beta/.meta/generator/beta_cases.rb') do
+      subject.stub(:cases_load_name, 'test/fixtures/xruby/exercises/beta/.meta/generator/beta_case.rb') do
         assert_instance_of TemplateValues, subject.template_values
       end
     end
 
     def test_template_values_loads_problem_case_classes
       subject = TestTemplateValuesFactory.new
-      subject.stub(:cases_load_name, 'test/fixtures/xruby/exercises/alpha/.meta/generator/alpha_cases.rb') do
+      subject.stub(:cases_load_name, 'test/fixtures/xruby/exercises/alpha/.meta/generator/alpha_case.rb') do
         assert_instance_of TemplateValues, subject.template_values
         assert Object.const_defined?(:AlphaCase)
       end

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -71,41 +71,25 @@ module Generator
       include TemplateValuesFactory
     end
 
-    class ClassBasedTestTemplateValuesFactory
+    class ClassBasedTestTemplateValuesFactory < TestTemplateValuesFactory
       def slug
         'beta'
       end
-
-      def version
-        2
-      end
-
-      def canonical_data
-        mock_canonical_data = Minitest::Mock.new
-        mock_canonical_data.expect :abbreviated_commit_hash, nil
-        mock_canonical_data.expect :version, '1.2.3'
-        mock_canonical_data.expect :to_s, '{"cases":[]}'
-        mock_canonical_data
-      end
-
-      def paths
-        mock_paths = Minitest::Mock.new
-        mock_paths.expect :track, 'test/fixtures/xruby'
-        mock_paths
-      end
-
-      include TemplateValuesFactory
     end
 
     def test_template_values_from_class
       subject = ClassBasedTestTemplateValuesFactory.new
-      assert_instance_of TemplateValues, subject.template_values
+      subject.stub(:cases_load_name, 'test/fixtures/xruby/exercises/beta/.meta/generator/beta_cases.rb') do
+        assert_instance_of TemplateValues, subject.template_values
+      end
     end
 
     def test_template_values_loads_problem_case_classes
       subject = TestTemplateValuesFactory.new
-      assert_instance_of TemplateValues, subject.template_values
-      assert Object.const_defined?(:AlphaCase)
+      subject.stub(:cases_load_name, 'test/fixtures/xruby/exercises/alpha/.meta/generator/alpha_cases.rb') do
+        assert_instance_of TemplateValues, subject.template_values
+        assert Object.const_defined?(:AlphaCase)
+      end
     end
 
     def teardown


### PR DESCRIPTION
There's a `Case` object (with a `test_class` and a `filepath`) lurking in here, but I'm not sure it's worth extracting into its own class until we tackle the larger composition issues.

This PR is intended to prep us for composition rather than including, or at least not get in the way.