### PR TITLE
generator: blindly rename Repository to Exercise

### DIFF
--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -13,14 +13,14 @@ module Generator
 
   # This contains the order for updating/generating the files. (Strategy pattern).
   # Doesn't update the version information.
-  class GenerateTests < RepositoryDelegator
+  class GenerateTests < ExerciseDelegator
     def call
       create_tests_file
     end
   end
 
   # Update everything.
-  class UpdateVersionAndGenerateTests < RepositoryDelegator
+  class UpdateVersionAndGenerateTests < ExerciseDelegator
     def call
       update_tests_version
       update_example_solution

--- a/lib/generator/command_line.rb
+++ b/lib/generator/command_line.rb
@@ -16,15 +16,15 @@ module Generator
     attr_reader :paths
 
     def generators
-      exercises.map { |slug| generator(repository(slug)) }
+      exercises.map { |slug| generator(exercise(slug)) }
     end
 
     def exercises
       @options[:all] ? Files::GeneratorCases.available(paths.track) : [@options[:slug]]
     end
 
-    def generator(repository)
-      generator_class.new(repository)
+    def generator(exercise)
+      generator_class.new(exercise)
     end
 
     def generator_class
@@ -35,9 +35,9 @@ module Generator
       @options[:freeze] || @options[:all]
     end
 
-    def repository(slug)
-      LoggingRepository.new(
-        repository: Repository.new(paths: paths, slug: slug),
+    def exercise(slug)
+      LoggingExercise.new(
+        exercise: Exercise.new(paths: paths, slug: slug),
         logger: logger
       )
     end

--- a/lib/generator/command_line/generator_optparser.rb
+++ b/lib/generator/command_line/generator_optparser.rb
@@ -54,16 +54,16 @@ module Generator
 
     def validate_paths
       return true if File.directory?(@paths.metadata)
-      $stderr.puts metadata_repository_missing_message(@paths.metadata)
+      $stderr.puts metadata_exercise_missing_message(@paths.metadata)
       false
     end
 
-    def metadata_repository_missing_message(repository)
+    def metadata_exercise_missing_message(exercise)
       <<-EOM.gsub(/^ {6}/, '')
 
-      'x-common' repository not found.
+      'x-common' exercise not found.
       Try running the command:
-        git clone https://github.com/exercism/x-common.git "#{repository}"
+        git clone https://github.com/exercism/x-common.git "#{exercise}"
 
       EOM
     end

--- a/lib/generator/exercise.rb
+++ b/lib/generator/exercise.rb
@@ -1,7 +1,7 @@
 require 'delegate'
 
 module Generator
-  class Repository
+  class Exercise
     include Files::TrackFiles
     include Files::MetadataFiles
     include TemplateValuesFactory
@@ -38,28 +38,28 @@ module Generator
   end
 
   # This exists to give us a clue as to what we are delegating to.
-  class RepositoryDelegator < SimpleDelegator
+  class ExerciseDelegator < SimpleDelegator
   end
 
-  # A repository that also logs its progress.
-  class LoggingRepository < RepositoryDelegator
-    def initialize(repository:, logger:)
-      __setobj__ @repository = repository
+  # A exercise that also logs its progress.
+  class LoggingExercise < ExerciseDelegator
+    def initialize(exercise:, logger:)
+      __setobj__ @exercise = exercise
       @logger = logger
     end
 
     def update_tests_version
-      @repository.update_tests_version
+      @exercise.update_tests_version
       @logger.debug "Incremented tests version to #{version}"
     end
 
     def update_example_solution
-      @repository.update_example_solution
+      @exercise.update_example_solution
       @logger.debug "Updated version in example solution to #{version}"
     end
 
     def create_tests_file
-      @repository.create_tests_file
+      @exercise.create_tests_file
       @logger.info "Generated #{slug} tests version #{version}"
     end
   end

--- a/lib/generator/files.rb
+++ b/lib/generator/files.rb
@@ -7,10 +7,10 @@ module Generator
     end
 
     class Readable
-      attr_reader :filename, :repository_root
-      def initialize(filename:, repository_root: nil)
+      attr_reader :filename, :exercise_root
+      def initialize(filename:, exercise_root: nil)
         @filename = filename
-        @repository_root = repository_root
+        @exercise_root = exercise_root
       end
 
       def to_s
@@ -24,11 +24,11 @@ module Generator
       private
 
       def relative_filename
-        Pathname.new(filename).relative_path_from(Pathname.new(repository_root)).to_s
+        Pathname.new(filename).relative_path_from(Pathname.new(exercise_root)).to_s
       end
 
       def git_path
-        File.join(repository_root, '.git')
+        File.join(exercise_root, '.git')
       end
     end
 
@@ -47,7 +47,7 @@ module Generator
       end
     end
 
-    # An Exercise is used as part of a Repository
+    # An Exercise is used as part of a Exercise
     # so expects :paths and :slug to be defined.
     module Exercise
       def paths

--- a/lib/generator/files/metadata_files.rb
+++ b/lib/generator/files/metadata_files.rb
@@ -6,7 +6,7 @@ module Generator
       def canonical_data
         CanonicalDataFile.new(
           filename: File.join(exercise_metadata_path, 'canonical-data.json'),
-          repository_root: paths.metadata)
+          exercise_root: paths.metadata)
       end
 
       private

--- a/lib/generator/git_command.rb
+++ b/lib/generator/git_command.rb
@@ -1,8 +1,8 @@
 module Generator
   # Wrap git shell commands.
   class GitCommand
-    def self.abbreviated_commit_hash(git_path, repository_relative_path)
-      `git --git-dir=#{git_path} log -1 --pretty=format:'%h' -- #{repository_relative_path}`
+    def self.abbreviated_commit_hash(git_path, exercise_relative_path)
+      `git --git-dir=#{git_path} log -1 --pretty=format:'%h' -- #{exercise_relative_path}`
     end
   end
 end

--- a/test/generator/command_line/generator_optparser_test.rb
+++ b/test/generator/command_line/generator_optparser_test.rb
@@ -86,10 +86,10 @@ module Generator
       end
     end
 
-    def test_invalid_metadata_repository_outputs_message_to_stderr
+    def test_invalid_metadata_exercise_outputs_message_to_stderr
       paths = Paths.new(metadata: 'test/fixtures/nonexistent', track: nil)
       expected_stderr = <<-MESSAGE.gsub(/^ {6}/, '')
-      'x-common' repository not found.
+      'x-common' exercise not found.
       Try running the command:
         git clone https://github.com/exercism/x-common.git "test/fixtures/nonexistent"
       MESSAGE

--- a/test/generator/command_line_test.rb
+++ b/test/generator/command_line_test.rb
@@ -14,10 +14,10 @@ module Generator
       end
     end
 
-    def test_invalid_metadata_repository_outputs_message_to_stderr
+    def test_invalid_metadata_exercise_outputs_message_to_stderr
       paths = Paths.new(metadata: 'test/fixtures/nonexistent', track: nil)
       expected_stderr = <<-MESSAGE.gsub(/^ {6}/, '')
-      'x-common' repository not found.
+      'x-common' exercise not found.
       Try running the command:
         git clone https://github.com/exercism/x-common.git "test/fixtures/nonexistent"
       MESSAGE

--- a/test/generator/exercise_test.rb
+++ b/test/generator/exercise_test.rb
@@ -1,25 +1,25 @@
 require_relative '../test_helper'
 
 module Generator
-  class RepositoryTest < Minitest::Test
+  class ExerciseTest < Minitest::Test
     FixturePaths = Paths.new(
       metadata: 'test/fixtures/metadata',
       track: 'test/fixtures/xruby'
     )
 
     def test_version
-      subject = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Exercise.new(paths: FixturePaths, slug: 'alpha')
       assert_equal 1, subject.version
     end
 
     def test_slug
-      subject = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Exercise.new(paths: FixturePaths, slug: 'alpha')
       assert_equal 'alpha', subject.slug
     end
 
     def test_update_tests_version
       mock_file = Minitest::Mock.new.expect :write, '2'.length, [2]
-      subject = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Exercise.new(paths: FixturePaths, slug: 'alpha')
       # Verify iniital condition from fixture file
       assert_equal 1, subject.tests_version.to_i
       File.stub(:open, true, mock_file) do
@@ -31,7 +31,7 @@ module Generator
     def test_update_example_solution
       expected_content = "# This is the example\n\nclass BookKeeping\n  VERSION = 1\nend\n"
       mock_file = Minitest::Mock.new.expect :write, expected_content.length, [expected_content]
-      subject = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Exercise.new(paths: FixturePaths, slug: 'alpha')
       File.stub(:open, true, mock_file) do
         assert_equal expected_content, subject.update_example_solution
       end
@@ -40,7 +40,7 @@ module Generator
 
     def test_create_tests_file
       # Q: Is the pain here caused by:
-      # a) Repository `including` everything rather than using composition?
+      # a) Exercise `including` everything rather than using composition?
       # b) Trying to verify the expected content.
       # c) The expected content being too long
       #
@@ -84,7 +84,7 @@ class AlphaTest < Minitest::Test
 end
 TESTS_FILE
       mock_file = Minitest::Mock.new.expect :write, expected_content.length, [expected_content]
-      subject = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Exercise.new(paths: FixturePaths, slug: 'alpha')
       GitCommand.stub(:abbreviated_commit_hash, '123456789') do
         File.stub(:open, true, mock_file) do
           assert_equal expected_content, subject.create_tests_file
@@ -96,50 +96,50 @@ TESTS_FILE
     end
 
     def test_exercise_name
-      subject = Repository.new(paths: FixturePaths, slug: 'alpha-beta')
+      subject = Exercise.new(paths: FixturePaths, slug: 'alpha-beta')
       assert_equal 'alpha_beta', subject.exercise_name
     end
   end
 
-  class LoggingRepositoryTest < Minitest::Test
+  class LoggingExerciseTest < Minitest::Test
     def test_create_tests_file
-      mock_repository = Minitest::Mock.new
-      mock_repository.expect :create_tests_file, nil
-      mock_repository.expect :slug, 'alpha'
-      mock_repository.expect :version, 2
+      mock_exercise = Minitest::Mock.new
+      mock_exercise.expect :create_tests_file, nil
+      mock_exercise.expect :slug, 'alpha'
+      mock_exercise.expect :version, 2
       mock_logger = Minitest::Mock.new
       mock_logger.expect :info, nil, ['Generated alpha tests version 2']
 
-      subject = LoggingRepository.new(repository: mock_repository, logger: mock_logger)
+      subject = LoggingExercise.new(exercise: mock_exercise, logger: mock_logger)
       subject.create_tests_file
 
-      mock_repository.verify
+      mock_exercise.verify
     end
 
     def test_update_tests_version
-      mock_repository = Minitest::Mock.new
-      mock_repository.expect :update_tests_version, nil
-      mock_repository.expect :version, 2
+      mock_exercise = Minitest::Mock.new
+      mock_exercise.expect :update_tests_version, nil
+      mock_exercise.expect :version, 2
       mock_logger = Minitest::Mock.new
       mock_logger.expect :debug, nil, ['Incremented tests version to 2']
 
-      subject = LoggingRepository.new(repository: mock_repository, logger: mock_logger)
+      subject = LoggingExercise.new(exercise: mock_exercise, logger: mock_logger)
       subject.update_tests_version
 
-      mock_repository.verify
+      mock_exercise.verify
     end
 
     def test_update_example_solution
-      mock_repository = Minitest::Mock.new
-      mock_repository.expect :update_example_solution, nil
-      mock_repository.expect :version, 2
+      mock_exercise = Minitest::Mock.new
+      mock_exercise.expect :update_example_solution, nil
+      mock_exercise.expect :version, 2
       mock_logger = Minitest::Mock.new
       mock_logger.expect :debug, nil, ['Updated version in example solution to 2']
 
-      subject = LoggingRepository.new(repository: mock_repository, logger: mock_logger)
+      subject = LoggingExercise.new(exercise: mock_exercise, logger: mock_logger)
       subject.update_example_solution
 
-      mock_repository.verify
+      mock_exercise.verify
     end
   end
 end

--- a/test/generator/files_test.rb
+++ b/test/generator/files_test.rb
@@ -23,7 +23,7 @@ module Generator
     class ReadableTest < Minitest::Test
       def test_abbreviated_commit_hash
         mock_git_command = Minitest::Mock.new.expect :call, nil, ['path/.git', 'subdir/file']
-        subject = Readable.new(filename: 'path/subdir/file', repository_root: 'path')
+        subject = Readable.new(filename: 'path/subdir/file', exercise_root: 'path')
         GitCommand.stub(:abbreviated_commit_hash, mock_git_command) do
           subject.abbreviated_commit_hash
         end

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -3,27 +3,27 @@ require_relative 'test_helper'
 module Generator
   class UpdateVersionAndGenerateTestsTest < Minitest::Test
     def test_call
-      mock_repository = Minitest::Mock.new
-      mock_repository.expect :update_tests_version, nil
-      mock_repository.expect :update_example_solution, nil
-      mock_repository.expect :create_tests_file, nil
+      mock_exercise = Minitest::Mock.new
+      mock_exercise.expect :update_tests_version, nil
+      mock_exercise.expect :update_example_solution, nil
+      mock_exercise.expect :create_tests_file, nil
 
-      subject = UpdateVersionAndGenerateTests.new(mock_repository)
+      subject = UpdateVersionAndGenerateTests.new(mock_exercise)
       subject.call
 
-      mock_repository.verify
+      mock_exercise.verify
     end
   end
 
   class UpdateVersionAndGenerateTestsFrozenVersionTest < Minitest::Test
     def test_call
-      mock_repository = Minitest::Mock.new
-      mock_repository.expect :create_tests_file, nil
+      mock_exercise = Minitest::Mock.new
+      mock_exercise.expect :create_tests_file, nil
 
-      subject = GenerateTests.new(mock_repository)
+      subject = GenerateTests.new(mock_exercise)
       subject.call
 
-      mock_repository.verify
+      mock_exercise.verify
     end
   end
 


### PR DESCRIPTION
first step in refactoring the Repository model. Renaming it to Exercise. part of exercism/xruby#633