### PR TITLE
generator: rename Repository model

### DIFF
--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -13,14 +13,14 @@ module Generator
 
   # This contains the order for updating/generating the files. (Strategy pattern).
   # Doesn't update the version information.
-  class GenerateTests < RepositoryDelegator
+  class GenerateTests < ExerciseDelegator
     def call
       create_tests_file
     end
   end
 
   # Update everything.
-  class UpdateVersionAndGenerateTests < RepositoryDelegator
+  class UpdateVersionAndGenerateTests < ExerciseDelegator
     def call
       update_tests_version
       update_example_solution

--- a/lib/generator/command_line.rb
+++ b/lib/generator/command_line.rb
@@ -16,15 +16,15 @@ module Generator
     attr_reader :paths
 
     def generators
-      exercises.map { |slug| generator(repository(slug)) }
+      exercises.map { |slug| generator(exercise(slug)) }
     end
 
     def exercises
       @options[:all] ? Files::GeneratorCases.available(paths.track) : [@options[:slug]]
     end
 
-    def generator(repository)
-      generator_class.new(repository)
+    def generator(exercise)
+      generator_class.new(exercise)
     end
 
     def generator_class
@@ -35,9 +35,9 @@ module Generator
       @options[:freeze] || @options[:all]
     end
 
-    def repository(slug)
-      LoggingRepository.new(
-        repository: Repository.new(paths: paths, slug: slug),
+    def exercise(slug)
+      LoggingExercise.new(
+        exercise: Exercise.new(paths: paths, slug: slug),
         logger: logger
       )
     end

--- a/lib/generator/exercise.rb
+++ b/lib/generator/exercise.rb
@@ -1,7 +1,7 @@
 require 'delegate'
 
 module Generator
-  class Repository
+  class Exercise
     include Files::TrackFiles
     include Files::MetadataFiles
     include TemplateValuesFactory
@@ -38,28 +38,28 @@ module Generator
   end
 
   # This exists to give us a clue as to what we are delegating to.
-  class RepositoryDelegator < SimpleDelegator
+  class ExerciseDelegator < SimpleDelegator
   end
 
-  # A repository that also logs its progress.
-  class LoggingRepository < RepositoryDelegator
-    def initialize(repository:, logger:)
-      __setobj__ @repository = repository
+  # A exercise that also logs its progress.
+  class LoggingExercise < ExerciseDelegator
+    def initialize(exercise:, logger:)
+      __setobj__ @exercise = exercise
       @logger = logger
     end
 
     def update_tests_version
-      @repository.update_tests_version
+      @exercise.update_tests_version
       @logger.debug "Incremented tests version to #{version}"
     end
 
     def update_example_solution
-      @repository.update_example_solution
+      @exercise.update_example_solution
       @logger.debug "Updated version in example solution to #{version}"
     end
 
     def create_tests_file
-      @repository.create_tests_file
+      @exercise.create_tests_file
       @logger.info "Generated #{slug} tests version #{version}"
     end
   end

--- a/lib/generator/files.rb
+++ b/lib/generator/files.rb
@@ -46,17 +46,5 @@ module Generator
         end
       end
     end
-
-    # An Exercise is used as part of a Repository
-    # so expects :paths and :slug to be defined.
-    module Exercise
-      def paths
-        fail NotImplementedError, 'Should return a Generator::Paths object'
-      end
-
-      def slug
-        fail NotImplementedError, 'Should return a String object'
-      end
-    end
   end
 end

--- a/lib/generator/files/metadata_files.rb
+++ b/lib/generator/files/metadata_files.rb
@@ -1,8 +1,6 @@
 module Generator
   module Files
     module MetadataFiles
-      include Exercise
-
       def canonical_data
         CanonicalDataFile.new(
           filename: File.join(exercise_metadata_path, 'canonical-data.json'),

--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -3,8 +3,6 @@ require 'erb'
 module Generator
   module Files
     module TrackFiles
-      include Exercise
-
       def minitest_tests
         MinitestTestsFile.new(filename: File.join(exercise_path, minitest_tests_filename))
       end

--- a/test/generator/exercise_test.rb
+++ b/test/generator/exercise_test.rb
@@ -1,25 +1,25 @@
 require_relative '../test_helper'
 
 module Generator
-  class RepositoryTest < Minitest::Test
+  class ExerciseTest < Minitest::Test
     FixturePaths = Paths.new(
       metadata: 'test/fixtures/metadata',
       track: 'test/fixtures/xruby'
     )
 
     def test_version
-      subject = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Exercise.new(paths: FixturePaths, slug: 'alpha')
       assert_equal 1, subject.version
     end
 
     def test_slug
-      subject = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Exercise.new(paths: FixturePaths, slug: 'alpha')
       assert_equal 'alpha', subject.slug
     end
 
     def test_update_tests_version
       mock_file = Minitest::Mock.new.expect :write, '2'.length, [2]
-      subject = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Exercise.new(paths: FixturePaths, slug: 'alpha')
       # Verify iniital condition from fixture file
       assert_equal 1, subject.tests_version.to_i
       File.stub(:open, true, mock_file) do
@@ -31,7 +31,7 @@ module Generator
     def test_update_example_solution
       expected_content = "# This is the example\n\nclass BookKeeping\n  VERSION = 1\nend\n"
       mock_file = Minitest::Mock.new.expect :write, expected_content.length, [expected_content]
-      subject = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Exercise.new(paths: FixturePaths, slug: 'alpha')
       File.stub(:open, true, mock_file) do
         assert_equal expected_content, subject.update_example_solution
       end
@@ -40,7 +40,7 @@ module Generator
 
     def test_create_tests_file
       # Q: Is the pain here caused by:
-      # a) Repository `including` everything rather than using composition?
+      # a) Exercise `including` everything rather than using composition?
       # b) Trying to verify the expected content.
       # c) The expected content being too long
       #
@@ -84,7 +84,7 @@ class AlphaTest < Minitest::Test
 end
 TESTS_FILE
       mock_file = Minitest::Mock.new.expect :write, expected_content.length, [expected_content]
-      subject = Repository.new(paths: FixturePaths, slug: 'alpha')
+      subject = Exercise.new(paths: FixturePaths, slug: 'alpha')
       GitCommand.stub(:abbreviated_commit_hash, '123456789') do
         File.stub(:open, true, mock_file) do
           assert_equal expected_content, subject.create_tests_file
@@ -96,50 +96,50 @@ TESTS_FILE
     end
 
     def test_exercise_name
-      subject = Repository.new(paths: FixturePaths, slug: 'alpha-beta')
+      subject = Exercise.new(paths: FixturePaths, slug: 'alpha-beta')
       assert_equal 'alpha_beta', subject.exercise_name
     end
   end
 
-  class LoggingRepositoryTest < Minitest::Test
+  class LoggingExerciseTest < Minitest::Test
     def test_create_tests_file
-      mock_repository = Minitest::Mock.new
-      mock_repository.expect :create_tests_file, nil
-      mock_repository.expect :slug, 'alpha'
-      mock_repository.expect :version, 2
+      mock_exercise = Minitest::Mock.new
+      mock_exercise.expect :create_tests_file, nil
+      mock_exercise.expect :slug, 'alpha'
+      mock_exercise.expect :version, 2
       mock_logger = Minitest::Mock.new
       mock_logger.expect :info, nil, ['Generated alpha tests version 2']
 
-      subject = LoggingRepository.new(repository: mock_repository, logger: mock_logger)
+      subject = LoggingExercise.new(exercise: mock_exercise, logger: mock_logger)
       subject.create_tests_file
 
-      mock_repository.verify
+      mock_exercise.verify
     end
 
     def test_update_tests_version
-      mock_repository = Minitest::Mock.new
-      mock_repository.expect :update_tests_version, nil
-      mock_repository.expect :version, 2
+      mock_exercise = Minitest::Mock.new
+      mock_exercise.expect :update_tests_version, nil
+      mock_exercise.expect :version, 2
       mock_logger = Minitest::Mock.new
       mock_logger.expect :debug, nil, ['Incremented tests version to 2']
 
-      subject = LoggingRepository.new(repository: mock_repository, logger: mock_logger)
+      subject = LoggingExercise.new(exercise: mock_exercise, logger: mock_logger)
       subject.update_tests_version
 
-      mock_repository.verify
+      mock_exercise.verify
     end
 
     def test_update_example_solution
-      mock_repository = Minitest::Mock.new
-      mock_repository.expect :update_example_solution, nil
-      mock_repository.expect :version, 2
+      mock_exercise = Minitest::Mock.new
+      mock_exercise.expect :update_example_solution, nil
+      mock_exercise.expect :version, 2
       mock_logger = Minitest::Mock.new
       mock_logger.expect :debug, nil, ['Updated version in example solution to 2']
 
-      subject = LoggingRepository.new(repository: mock_repository, logger: mock_logger)
+      subject = LoggingExercise.new(exercise: mock_exercise, logger: mock_logger)
       subject.update_example_solution
 
-      mock_repository.verify
+      mock_exercise.verify
     end
   end
 end

--- a/test/generator/files_test.rb
+++ b/test/generator/files_test.rb
@@ -57,25 +57,5 @@ module Generator
         mock_writer.verify
       end
     end
-
-    class ExerciseTest < Minitest::Test
-      class TestNotImplementedTrackFiles
-        include Exercise
-      end
-
-      def test_paths_not_implemented
-        subject = TestNotImplementedTrackFiles.new
-        assert_raises NotImplementedError do
-          subject.paths
-        end
-      end
-
-      def test_slug_not_implemented
-        subject = TestNotImplementedTrackFiles.new
-        assert_raises NotImplementedError do
-          subject.slug
-        end
-      end
-    end
   end
 end

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -3,27 +3,27 @@ require_relative 'test_helper'
 module Generator
   class UpdateVersionAndGenerateTestsTest < Minitest::Test
     def test_call
-      mock_repository = Minitest::Mock.new
-      mock_repository.expect :update_tests_version, nil
-      mock_repository.expect :update_example_solution, nil
-      mock_repository.expect :create_tests_file, nil
+      mock_exercise = Minitest::Mock.new
+      mock_exercise.expect :update_tests_version, nil
+      mock_exercise.expect :update_example_solution, nil
+      mock_exercise.expect :create_tests_file, nil
 
-      subject = UpdateVersionAndGenerateTests.new(mock_repository)
+      subject = UpdateVersionAndGenerateTests.new(mock_exercise)
       subject.call
 
-      mock_repository.verify
+      mock_exercise.verify
     end
   end
 
   class UpdateVersionAndGenerateTestsFrozenVersionTest < Minitest::Test
     def test_call
-      mock_repository = Minitest::Mock.new
-      mock_repository.expect :create_tests_file, nil
+      mock_exercise = Minitest::Mock.new
+      mock_exercise.expect :create_tests_file, nil
 
-      subject = GenerateTests.new(mock_repository)
+      subject = GenerateTests.new(mock_exercise)
       subject.call
 
-      mock_repository.verify
+      mock_exercise.verify
     end
   end
 


### PR DESCRIPTION
Step 1 in separating out the Repository and Exercise models

(see also exercism/xruby#633)