### PR TITLE
[WIP] - Separate canonical data methods from ExerciseCase

### DIFF
--- a/exercises/acronym/.meta/generator/acronym_case.rb
+++ b/exercises/acronym/.meta/generator/acronym_case.rb
@@ -3,7 +3,7 @@ require 'generator/exercise_case'
 class AcronymCase < Generator::ExerciseCase
 
   def workload
-    assert_equal { "Acronym.abbreviate('#{phrase}')" }
+    assert_equal { "Acronym.abbreviate('#{canonical.phrase}')" }
   end
 
 end

--- a/exercises/beer-song/.meta/generator/beer_song_case.rb
+++ b/exercises/beer-song/.meta/generator/beer_song_case.rb
@@ -1,23 +1,22 @@
 require 'generator/exercise_case'
 
 class BeerSongCase < Generator::ExerciseCase
-
   def workload
-    %Q(expected = #{indent_heredoc(expected.split("\n"), 'TEXT', 0)}\n) +
-      "    assert_equal expected, #{beer_song}"
+    %(expected = #{indent_heredoc(canonical.expected.split("\n"), 'TEXT', 0)}\n) +
+      "    assert_equal expected, #{beer_song_call}"
   end
 
   private
 
-  def beer_song
-    "BeerSong.new.%s(%s)" % [property, beer_song_arguments]
+  def beer_song_call
+    format'BeerSong.new.%s(%s)', canonical.property, beer_song_arguments
   end
 
   def beer_song_arguments
-    if property == 'verse'
-      number
+    if canonical.property == 'verse'
+      canonical.number
     else
-      "%s, %s" % [self["beginning"], self["end"]]
+      format '%s, %s', canonical.beginning, canonical.end
     end
   end
 end

--- a/exercises/clock/.meta/generator/clock_case.rb
+++ b/exercises/clock/.meta/generator/clock_case.rb
@@ -2,34 +2,34 @@ require 'generator/exercise_case'
 
 class ClockCase < Generator::ExerciseCase
   def name
-    'test_%s' % description
+    'test_%s' % canonical.description
                 .gsub(/[() -]/, '_')
                 .gsub('=', 'is_equal_to')
                 .chomp('_')
   end
 
   def workload
-    property == 'equal' ? compare_clocks : simple_test
+    canonical.property == 'equal' ? compare_clocks : simple_test
   end
 
   private
 
   def compare_clocks
-    "clock1 = Clock.at(#{clock1['hour']}, #{clock1['minute']})
-    clock2 = Clock.at(#{clock2['hour']}, #{clock2['minute']})
+    "clock1 = Clock.at(#{canonical.clock1['hour']}, #{canonical.clock1['minute']})
+    clock2 = Clock.at(#{canonical.clock2['hour']}, #{canonical.clock2['minute']})
     #{assert} clock1 == clock2"
   end
 
   def simple_test
     [
-      "assert_equal #{expected.inspect}, ",
-      "#{'(' if add_to_clock}Clock.at(#{hour}, ",
-      "#{minute})#{add_to_clock}#{')' if add_to_clock}.to_s"
+      "assert_equal #{canonical.expected.inspect}, ",
+      "#{'(' if add_to_clock}Clock.at(#{canonical.hour}, ",
+      "#{canonical.minute})#{add_to_clock}#{')' if add_to_clock}.to_s"
     ].join
   end
 
   def add_to_clock
-    " + #{add}" if add
+    " + #{canonical.add}" if canonical.add
   end
 
 end

--- a/exercises/wordy/.meta/generator/wordy_case.rb
+++ b/exercises/wordy/.meta/generator/wordy_case.rb
@@ -4,7 +4,7 @@ class WordyCase < Generator::ExerciseCase
 
   def workload
     [
-      "question = '#{input}'",
+      "question = '#{case_data['input']}'",
       indent(4, assertion),
     ].join("\n")
   end
@@ -16,10 +16,10 @@ class WordyCase < Generator::ExerciseCase
   end
 
   def assertion
-    return error_assertion unless expected
+    return error_assertion unless case_data['expected']
     return message_assertion if message
 
-    "assert_equal(#{expected}, WordProblem.new(question).answer)"
+    "assert_equal(#{case_data['expected']}, WordProblem.new(question).answer)"
   end
 
   def error_assertion
@@ -34,12 +34,12 @@ class WordyCase < Generator::ExerciseCase
     [
       'answer = WordProblem.new(question).answer',
       "message = \"#{message % '#{answer}'}\"",
-      "assert_equal(#{expected}, answer, message)",
+      "assert_equal(#{case_data['expected']}, answer, message)",
     ].join("\n")
   end
 
   def message
-    return unless input == 'What is -3 plus 7 multiplied by -2?'
+    return unless case_data['input'] == 'What is -3 plus 7 multiplied by -2?'
 
     'You should ignore order of precedence. -3 + 7 * -2 = -8, not %s'
   end

--- a/exercises/wordy/.meta/generator/wordy_case.rb
+++ b/exercises/wordy/.meta/generator/wordy_case.rb
@@ -4,7 +4,7 @@ class WordyCase < Generator::ExerciseCase
 
   def workload
     [
-      "question = '#{case_data['input']}'",
+      "question = '#{canonical['input']}'",
       indent(4, assertion),
     ].join("\n")
   end
@@ -16,10 +16,10 @@ class WordyCase < Generator::ExerciseCase
   end
 
   def assertion
-    return error_assertion unless case_data['expected']
+    return error_assertion unless canonical['expected']
     return message_assertion if message
 
-    "assert_equal(#{case_data['expected']}, WordProblem.new(question).answer)"
+    "assert_equal(#{canonical['expected']}, WordProblem.new(question).answer)"
   end
 
   def error_assertion
@@ -34,12 +34,12 @@ class WordyCase < Generator::ExerciseCase
     [
       'answer = WordProblem.new(question).answer',
       "message = \"#{message % '#{answer}'}\"",
-      "assert_equal(#{case_data['expected']}, answer, message)",
+      "assert_equal(#{canonical['expected']}, answer, message)",
     ].join("\n")
   end
 
   def message
-    return unless case_data['input'] == 'What is -3 plus 7 multiplied by -2?'
+    return unless canonical['input'] == 'What is -3 plus 7 multiplied by -2?'
 
     'You should ignore order of precedence. -3 + 7 * -2 = -8, not %s'
   end

--- a/lib/generator/case_values.rb
+++ b/lib/generator/case_values.rb
@@ -7,7 +7,7 @@ module Generator
 
       def cases(exercise_data)
         extract_test_cases(data: JSON.parse(exercise_data)['cases'])
-          .map { |test| @case_class.new(case_data: test) }
+          .map { |test| @case_class.new(canonical: test) }
       end
 
       private

--- a/lib/generator/case_values.rb
+++ b/lib/generator/case_values.rb
@@ -7,7 +7,7 @@ module Generator
 
       def cases(exercise_data)
         extract_test_cases(data: JSON.parse(exercise_data)['cases'])
-          .map { |test| @case_class.new(test) }
+          .map { |test| @case_class.new(case_data: test) }
       end
 
       private

--- a/lib/generator/case_values.rb
+++ b/lib/generator/case_values.rb
@@ -7,7 +7,7 @@ module Generator
 
       def cases(exercise_data)
         extract_test_cases(data: JSON.parse(exercise_data)['cases'])
-          .map { |test| @case_class.new(canonical: test) }
+          .map { |case_properties| @case_class.new(canonical: OpenStruct.new(case_properties)) }
       end
 
       private

--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -6,13 +6,13 @@ module Generator
     include CaseHelpers
     include Assertion
 
-    attr_reader :case_data
-    def initialize(case_data:)
-      @case_data = case_data
+    attr_reader :canonical
+    def initialize(canonical:)
+      @canonical = canonical
     end
 
     def name
-      'test_%s' % case_data['description'].underscore
+      'test_%s' % canonical['description'].underscore
     end
 
     def skipped(index)

--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -9,6 +9,7 @@ module Generator
     attr_reader :canonical
     def initialize(canonical:)
       @canonical = canonical
+      setup_forwards(canonical)
     end
 
     def name
@@ -17,6 +18,18 @@ module Generator
 
     def skipped(index)
       index.zero? ? '# skip' : 'skip'
+    end
+
+    private
+
+    def setup_forwards(data)
+      data.to_h.keys.each do |key|
+        send(:define_singleton_method, key) { forward(key) }
+      end
+    end
+
+    def forward(key)
+      canonical.send(key)
     end
   end
 end

--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -12,7 +12,7 @@ module Generator
     end
 
     def name
-      'test_%s' % canonical['description'].underscore
+      'test_%s' % description.underscore
     end
 
     def skipped(index)

--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -1,50 +1,22 @@
 require 'ostruct'
 
 module Generator
-  class ExerciseCase < OpenStruct
+  class ExerciseCase
     using Generator::Underscore
+    include CaseHelpers
     include Assertion
 
+    attr_reader :case_data
+    def initialize(case_data:)
+      @case_data = case_data
+    end
+
     def name
-      'test_%s' % description.underscore
+      'test_%s' % case_data['description'].underscore
     end
 
-    def skipped(idx)
-      idx.zero? ? '# skip' : 'skip'
-    end
-
-    protected
-
-    # indent multi line workloads
-    #
-    #   indent_lines(
-    #     [
-    #       "string = #{input.inspect}",
-    #       "#{assert} Isogram.is_isogram?(string)"
-    #     ], 4
-    #   )
-    def indent_lines(code, depth, separator = "\n")
-      code.join(separator + ' ' * depth)
-    end
-
-    # indent multi line workloads with (unindented) blank lines
-    #
-    #   indent_text(4, text)
-    def indent_text(depth, text)
-      text.lines.reduce do |obj, line|
-        obj << (line == "\n" ? line : ' ' * depth + line)
-      end
-    end
-
-    # generate heredoc (as part of workload) with optional indentation
-    #
-    #    indent_heredoc(["foo", "bar"], 'TEXT', 1)
-    def indent_heredoc(lines, delimiter, depth = 0, delimiter_method = nil)
-      [
-        "<<-#{delimiter}#{delimiter_method}",
-        lines.map { |line| ' ' * depth + line }.join("\n"),
-        delimiter
-      ].join("\n")
+    def skipped(index)
+      index.zero? ? '# skip' : 'skip'
     end
   end
 end

--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -13,7 +13,7 @@ module Generator
     end
 
     def name
-      'test_%s' % description.underscore
+      'test_%s' % canonical.description.underscore
     end
 
     def skipped(index)

--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -29,6 +29,7 @@ module Generator
     end
 
     def forward(key)
+      warn "WARNING: Forwarding '#{key}' to 'canonical.#{key}'\n"
       canonical.send(key)
     end
   end

--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -1,5 +1,4 @@
 require 'ostruct'
-require 'json'
 
 module Generator
   class ExerciseCase < OpenStruct

--- a/lib/generator/exercise_case.rb
+++ b/lib/generator/exercise_case.rb
@@ -29,7 +29,6 @@ module Generator
     end
 
     def forward(key)
-      warn "WARNING: Forwarding '#{key}' to 'canonical.#{key}'\n"
       canonical.send(key)
     end
   end

--- a/lib/generator/exercise_case/assertion.rb
+++ b/lib/generator/exercise_case/assertion.rb
@@ -1,31 +1,59 @@
 module Generator
-  class ExerciseCase < OpenStruct
+  class ExerciseCase
     module Assertion
 
+      # generates assertions of the form
+      #
+      #   assert whatever
+      #   refute whatever
+      #
+      # depending on whether 'expected' is true or false
+      #
+      # call as
+      #
       #  "#{assert} Luhn.valid?(#{input.inspect})"
+      #
       def assert
-        expected ? 'assert' : 'refute'
+        case_data['expected'] ? 'assert' : 'refute'
       end
 
-      # e.g.,
+      # generates assertions of the form
+      #
+      #   assert_nil whatever
+      #   assert_equal expected, whatever
+      #
+      # depending on whether 'expected' is nil or not
+      #
+      # call as
+      #
       #   assert_equal { "PigLatin.translate(#{input.inspect})" }
+      #
       def assert_equal
-        assertion = expected.nil? ? 'assert_nil' : "assert_equal #{expected.inspect},"
+        assertion = case_data['expected'].nil? ? 'assert_nil' :
+                      "assert_equal #{case_data['expected'].inspect},"
         "#{assertion} #{yield}"
       end
 
-      # e.g.,
+      # a helper function, used to build statements such as
+      #
       #   if raises_error?
       #     assert_raises(ArgumentError) { test_case }
       #   else
       #     assert_equal { test_case }
       #   end
+      #
       def raises_error?
-        expected.to_i == -1
+        case_data['expected'].to_i == -1
       end
 
-      # e.g.,
+      # generates assertions of the form
+      #
+      #   assert_raises(SomeError) { whatever }
+      #
+      # call as
+      #
       #   assert_raises(ArgumentError) { test_case }
+      #
       def assert_raises(error)
         "assert_raises(#{error}) { #{yield} }"
       end

--- a/lib/generator/exercise_case/assertion.rb
+++ b/lib/generator/exercise_case/assertion.rb
@@ -14,7 +14,7 @@ module Generator
       #  "#{assert} Luhn.valid?(#{input.inspect})"
       #
       def assert
-        case_data['expected'] ? 'assert' : 'refute'
+        canonical['expected'] ? 'assert' : 'refute'
       end
 
       # generates assertions of the form
@@ -29,8 +29,8 @@ module Generator
       #   assert_equal { "PigLatin.translate(#{input.inspect})" }
       #
       def assert_equal
-        assertion = case_data['expected'].nil? ? 'assert_nil' :
-                      "assert_equal #{case_data['expected'].inspect},"
+        assertion = canonical['expected'].nil? ? 'assert_nil' :
+                      "assert_equal #{canonical['expected'].inspect},"
         "#{assertion} #{yield}"
       end
 
@@ -43,7 +43,7 @@ module Generator
       #   end
       #
       def raises_error?
-        case_data['expected'].to_i == -1
+        canonical['expected'].to_i == -1
       end
 
       # generates assertions of the form

--- a/lib/generator/exercise_case/assertion.rb
+++ b/lib/generator/exercise_case/assertion.rb
@@ -14,7 +14,7 @@ module Generator
       #  "#{assert} Luhn.valid?(#{input.inspect})"
       #
       def assert
-        canonical['expected'] ? 'assert' : 'refute'
+        canonical.expected ? 'assert' : 'refute'
       end
 
       # generates assertions of the form
@@ -29,8 +29,8 @@ module Generator
       #   assert_equal { "PigLatin.translate(#{input.inspect})" }
       #
       def assert_equal
-        assertion = canonical['expected'].nil? ? 'assert_nil' :
-                      "assert_equal #{canonical['expected'].inspect},"
+        assertion = canonical.expected.nil? ? 'assert_nil' :
+                      "assert_equal #{canonical.expected.inspect},"
         "#{assertion} #{yield}"
       end
 
@@ -43,7 +43,7 @@ module Generator
       #   end
       #
       def raises_error?
-        canonical['expected'].to_i == -1
+        canonical.expected.to_i == -1
       end
 
       # generates assertions of the form

--- a/lib/generator/exercise_case/case_helpers.rb
+++ b/lib/generator/exercise_case/case_helpers.rb
@@ -1,0 +1,39 @@
+module Generator
+  class ExerciseCase
+    module CaseHelpers
+      protected
+
+      # indent multi line workloads
+      #
+      #   indent_lines(
+      #     [
+      #       "string = #{input.inspect}",
+      #       "#{assert} Isogram.is_isogram?(string)"
+      #     ], 4
+      #   )
+      def indent_lines(code, depth, separator = "\n")
+        code.join(separator + ' ' * depth)
+      end
+
+      # indent multi line workloads with (unindented) blank lines
+      #
+      #   indent_text(4, text)
+      def indent_text(depth, text)
+        text.lines.reduce do |obj, line|
+          obj << (line == "\n" ? line : ' ' * depth + line)
+        end
+      end
+
+      # generate heredoc (as part of workload) with optional indentation
+      #
+      #    indent_heredoc(["foo", "bar"], 'TEXT', 1)
+      def indent_heredoc(lines, delimiter, depth = 0, delimiter_method = nil)
+        [
+          "<<-#{delimiter}#{delimiter_method}",
+          lines.map { |line| ' ' * depth + line }.join("\n"),
+          delimiter
+        ].join("\n")
+      end
+    end
+  end
+end

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Generator
   # Contains methods accessible to the ERB template
   class TemplateValues

--- a/test/fixtures/xruby/exercises/alpha/.meta/generator/alpha_case.rb
+++ b/test/fixtures/xruby/exercises/alpha/.meta/generator/alpha_case.rb
@@ -1,6 +1,6 @@
 class AlphaCase < Generator::ExerciseCase
   def name
-    format('test_%s', description.downcase.gsub(/[ -]/, '_'))
+    format('test_%s', canonical.description.downcase.gsub(/[ -]/, '_'))
   end
 
   def workload

--- a/test/generator/case_values_test.rb
+++ b/test/generator/case_values_test.rb
@@ -17,7 +17,7 @@ module Generator
 
         expected = [
           ComplexCase.new(
-            case_data: {
+            canonical: {
               'description' => 'first generic verse',
               'property' => 'verse',
               'number' => 99,
@@ -25,7 +25,7 @@ module Generator
             }
           ),
           ComplexCase.new(
-            case_data: {
+            canonical: {
               'description' => 'last generic verse',
               'property' => 'verse',
               'number' => 3,
@@ -33,7 +33,7 @@ module Generator
             }
           ),
           ComplexCase.new(
-            case_data: {
+            canonical: {
               'description' => 'first two verses',
               'property' => 'verses',
               'beginning' => 99,
@@ -43,7 +43,7 @@ module Generator
           )
         ]
         assert expected.zip(cases).all? do |exp, cs|
-          assert_equal exp.case_data, cs.case_data
+          assert_equal exp.canonical, cs.canonical
         end
       end
     end

--- a/test/generator/case_values_test.rb
+++ b/test/generator/case_values_test.rb
@@ -16,14 +16,35 @@ module Generator
         ).cases(canonical_data)
 
         expected = [
-          ComplexCase.new(description: 'first generic verse', property: 'verse', number: 99,
-                          expected: '99 bottles of beer on the wall, YAAAR'),
-          ComplexCase.new(description: 'last generic verse', property: 'verse', number: 3,
-                          expected: '3 bottles of beer on the wall, YAAAR'),
-          ComplexCase.new(description: 'first two verses', property: 'verses', beginning: 99, end: 98,
-                          expected: "99 bottles of beer on the wall, YAR, PIRATES CAN'T COUNT")
+          ComplexCase.new(
+            case_data: {
+              'description' => 'first generic verse',
+              'property' => 'verse',
+              'number' => 99,
+              'expected' => '99 bottles of beer on the wall, YAAAR'
+            }
+          ),
+          ComplexCase.new(
+            case_data: {
+              'description' => 'last generic verse',
+              'property' => 'verse',
+              'number' => 3,
+              'expected' => '3 bottles of beer on the wall, YAAAR'
+            }
+          ),
+          ComplexCase.new(
+            case_data: {
+              'description' => 'first two verses',
+              'property' => 'verses',
+              'beginning' => 99,
+              'end' => 98,
+              'expected' => "99 bottles of beer on the wall, YAR, PIRATES CAN'T COUNT"
+            }
+          )
         ]
-        assert_equal expected, cases
+        assert expected.zip(cases).all? do |exp, cs|
+          assert_equal exp.case_data, cs.case_data
+        end
       end
     end
   end

--- a/test/generator/exercise_case/assertion_test.rb
+++ b/test/generator/exercise_case/assertion_test.rb
@@ -4,43 +4,43 @@ module Generator
   class ExerciseCase
     class AssertionTest < Minitest::Test
       def test_assert
-        test_case = OpenStruct.new(case_data: {'expected' => true})
+        test_case = OpenStruct.new(canonical: {'expected' => true})
         test_case.extend(Assertion)
         assert_equal 'assert', test_case.assert
       end
 
       def test_refute
-        test_case = OpenStruct.new(case_data: {'expected' => false})
+        test_case = OpenStruct.new(canonical: {'expected' => false})
         test_case.extend(Assertion)
         assert_equal 'refute', test_case.assert
       end
 
       def test_assert_equal
-        test_case = OpenStruct.new(case_data: {'expected' => 2})
+        test_case = OpenStruct.new(canonical: {'expected' => 2})
         test_case.extend(Assertion)
         assert_equal "assert_equal 2, 4", test_case.assert_equal { 1 + 3 }
       end
 
       def test_assert_equal_when_nil
-        test_case = OpenStruct.new(case_data: {'expected' => nil})
+        test_case = OpenStruct.new(canonical: {'expected' => nil})
         test_case.extend(Assertion)
         assert_equal "assert_nil 4", test_case.assert_equal { 1 + 3 }
       end
 
       def test_raises_error
-        test_case = OpenStruct.new(case_data: {'expected' => -1})
+        test_case = OpenStruct.new(canonical: {'expected' => -1})
         test_case.extend(Assertion)
         assert test_case.raises_error?
       end
 
       def test_does_not_raise_error
-        test_case = OpenStruct.new(case_data: {'expected' => 'cute kitties'})
+        test_case = OpenStruct.new(canonical: {'expected' => 'cute kitties'})
         test_case.extend(Assertion)
         refute test_case.raises_error?
       end
 
       def test_assert_raises
-        test_case = OpenStruct.new(case_data: {})
+        test_case = OpenStruct.new(canonical: {})
         test_case.extend(Assertion)
         assert_equal(
           "assert_raises(ArgumentError) { 4 }",

--- a/test/generator/exercise_case/assertion_test.rb
+++ b/test/generator/exercise_case/assertion_test.rb
@@ -4,43 +4,43 @@ module Generator
   class ExerciseCase
     class AssertionTest < Minitest::Test
       def test_assert
-        test_case = OpenStruct.new(canonical: {'expected' => true})
+        test_case = ExerciseCase.new(canonical: OpenStruct.new({'expected' => true}))
         test_case.extend(Assertion)
         assert_equal 'assert', test_case.assert
       end
 
       def test_refute
-        test_case = OpenStruct.new(canonical: {'expected' => false})
+        test_case = ExerciseCase.new(canonical: OpenStruct.new({'expected' => false}))
         test_case.extend(Assertion)
         assert_equal 'refute', test_case.assert
       end
 
       def test_assert_equal
-        test_case = OpenStruct.new(canonical: {'expected' => 2})
+        test_case = ExerciseCase.new(canonical: OpenStruct.new({'expected' => 2}))
         test_case.extend(Assertion)
         assert_equal "assert_equal 2, 4", test_case.assert_equal { 1 + 3 }
       end
 
       def test_assert_equal_when_nil
-        test_case = OpenStruct.new(canonical: {'expected' => nil})
+        test_case = ExerciseCase.new(canonical: OpenStruct.new({'expected' => nil}))
         test_case.extend(Assertion)
         assert_equal "assert_nil 4", test_case.assert_equal { 1 + 3 }
       end
 
       def test_raises_error
-        test_case = OpenStruct.new(canonical: {'expected' => -1})
+        test_case = ExerciseCase.new(canonical: OpenStruct.new({'expected' => -1}))
         test_case.extend(Assertion)
         assert test_case.raises_error?
       end
 
       def test_does_not_raise_error
-        test_case = OpenStruct.new(canonical: {'expected' => 'cute kitties'})
+        test_case = ExerciseCase.new(canonical: OpenStruct.new({'expected' => 'cute kitties'}))
         test_case.extend(Assertion)
         refute test_case.raises_error?
       end
 
       def test_assert_raises
-        test_case = OpenStruct.new(canonical: {})
+        test_case = ExerciseCase.new(canonical: OpenStruct.new({}))
         test_case.extend(Assertion)
         assert_equal(
           "assert_raises(ArgumentError) { 4 }",

--- a/test/generator/exercise_case/assertion_test.rb
+++ b/test/generator/exercise_case/assertion_test.rb
@@ -4,43 +4,43 @@ module Generator
   class ExerciseCase
     class AssertionTest < Minitest::Test
       def test_assert
-        test_case = OpenStruct.new(expected: true)
+        test_case = OpenStruct.new(case_data: {'expected' => true})
         test_case.extend(Assertion)
         assert_equal 'assert', test_case.assert
       end
 
       def test_refute
-        test_case = OpenStruct.new(expected: false)
+        test_case = OpenStruct.new(case_data: {'expected' => false})
         test_case.extend(Assertion)
         assert_equal 'refute', test_case.assert
       end
 
       def test_assert_equal
-        test_case = OpenStruct.new(expected: 2)
+        test_case = OpenStruct.new(case_data: {'expected' => 2})
         test_case.extend(Assertion)
         assert_equal "assert_equal 2, 4", test_case.assert_equal { 1 + 3 }
       end
 
       def test_assert_equal_when_nil
-        test_case = OpenStruct.new(expected: nil)
+        test_case = OpenStruct.new(case_data: {'expected' => nil})
         test_case.extend(Assertion)
         assert_equal "assert_nil 4", test_case.assert_equal { 1 + 3 }
       end
 
       def test_raises_error
-        test_case = OpenStruct.new(expected: -1)
+        test_case = OpenStruct.new(case_data: {'expected' => -1})
         test_case.extend(Assertion)
         assert test_case.raises_error?
       end
 
       def test_does_not_raise_error
-        test_case = OpenStruct.new(expected: 'cute kitties')
+        test_case = OpenStruct.new(case_data: {'expected' => 'cute kitties'})
         test_case.extend(Assertion)
         refute test_case.raises_error?
       end
 
       def test_assert_raises
-        test_case = OpenStruct.new
+        test_case = OpenStruct.new(case_data: {})
         test_case.extend(Assertion)
         assert_equal(
           "assert_raises(ArgumentError) { 4 }",

--- a/test/generator/exercise_case/case_helpers_test.rb
+++ b/test/generator/exercise_case/case_helpers_test.rb
@@ -1,0 +1,43 @@
+require_relative '../../test_helper'
+
+module Generator
+  class ExerciseCase
+    class CaseHelpersTest < Minitest::Test
+      class MultiLineCase
+        include CaseHelpers
+
+        def workload
+          indent_lines(['foo', 'bar'], 1)
+        end
+      end
+      def test_indent_multiline_workloads
+        expected = "foo\n bar"
+        assert_equal expected, MultiLineCase.new.workload
+      end
+
+      class BlankLineCase
+        include CaseHelpers
+
+        def workload
+          indent_text(2, "foo\n\nbar\n")
+        end
+      end
+      def test_indent_multiline_workloads_with_blank_lines
+        expected = "foo\n\n  bar\n"
+        assert_equal expected, BlankLineCase.new.workload
+      end
+
+      class HeredocCase
+        include CaseHelpers
+
+        def workload
+          indent_heredoc(["foo", "bar"], 'TEXT', 1)
+        end
+      end
+      def test_heredoc
+        expected = "<<-TEXT\n foo\n bar\nTEXT"
+        assert_equal expected, HeredocCase.new.workload
+      end
+    end
+  end
+end

--- a/test/generator/exercise_case_test.rb
+++ b/test/generator/exercise_case_test.rb
@@ -3,15 +3,15 @@ require_relative '../test_helper'
 module Generator
   class ExerciseCaseTest < Minitest::Test
     def test_name
-      assert_equal 'test_foo', ExerciseCase.new(canonical: {'description' => 'foo'}).name
+      assert_equal 'test_foo', ExerciseCase.new(canonical: OpenStruct.new({'description' => 'foo'})).name
     end
 
     def test_skipped_index_zero
-      assert_equal '# skip', ExerciseCase.new(canonical: {}).skipped(0)
+      assert_equal '# skip', ExerciseCase.new(canonical: nil).skipped(0)
     end
 
     def test_skipped_index_nonzero
-      assert_equal 'skip', ExerciseCase.new(canonical: {}).skipped(1)
+      assert_equal 'skip', ExerciseCase.new(canonical: nil).skipped(1)
     end
   end
 end

--- a/test/generator/exercise_case_test.rb
+++ b/test/generator/exercise_case_test.rb
@@ -3,45 +3,15 @@ require_relative '../test_helper'
 module Generator
   class ExerciseCaseTest < Minitest::Test
     def test_name
-      assert_equal 'test_foo', ExerciseCase.new(description: 'foo').name
+      assert_equal 'test_foo', ExerciseCase.new(case_data: {'description' => 'foo'}).name
     end
 
     def test_skipped_index_zero
-      assert_equal '# skip', ExerciseCase.new.skipped(0)
+      assert_equal '# skip', ExerciseCase.new(case_data: {}).skipped(0)
     end
 
     def test_skipped_index_nonzero
-      assert_equal 'skip', ExerciseCase.new.skipped(1)
-    end
-
-    class MultiLineCase < ExerciseCase
-      def workload
-        indent_lines(['foo', 'bar'], 1)
-      end
-    end
-    def test_indent_multiline_workloads
-      expected = "foo\n bar"
-      assert_equal expected, MultiLineCase.new.workload
-    end
-
-    class BlankLineCase < ExerciseCase
-      def workload
-        indent_text(2, "foo\n\nbar\n")
-      end
-    end
-    def test_indent_multiline_workloads_with_blank_lines
-      expected = "foo\n\n  bar\n"
-      assert_equal expected, BlankLineCase.new.workload
-    end
-
-    class HeredocCase < ExerciseCase
-      def workload
-        indent_heredoc(["foo", "bar"], 'TEXT', 1)
-      end
-    end
-    def test_heredoc
-      expected = "<<-TEXT\n foo\n bar\nTEXT"
-      assert_equal expected, HeredocCase.new.workload
+      assert_equal 'skip', ExerciseCase.new(case_data: {}).skipped(1)
     end
   end
 end

--- a/test/generator/exercise_case_test.rb
+++ b/test/generator/exercise_case_test.rb
@@ -3,15 +3,15 @@ require_relative '../test_helper'
 module Generator
   class ExerciseCaseTest < Minitest::Test
     def test_name
-      assert_equal 'test_foo', ExerciseCase.new(case_data: {'description' => 'foo'}).name
+      assert_equal 'test_foo', ExerciseCase.new(canonical: {'description' => 'foo'}).name
     end
 
     def test_skipped_index_zero
-      assert_equal '# skip', ExerciseCase.new(case_data: {}).skipped(0)
+      assert_equal '# skip', ExerciseCase.new(canonical: {}).skipped(0)
     end
 
     def test_skipped_index_nonzero
-      assert_equal 'skip', ExerciseCase.new(case_data: {}).skipped(1)
+      assert_equal 'skip', ExerciseCase.new(canonical: {}).skipped(1)
     end
   end
 end

--- a/test/wordy_cases_test.rb
+++ b/test/wordy_cases_test.rb
@@ -4,7 +4,7 @@ require_relative '../exercises/wordy/.meta/generator/wordy_case'
 
 class WordyCaseTest < Minitest::Test
   def test_workload_with_expected_and_no_message
-    test_case = WordyCase.new(expected: 1, input: 1)
+    test_case = WordyCase.new(case_data: {'expected' => 1, 'input' => 1})
 
     expected_workload = [
       'question = \'1\'',
@@ -15,7 +15,9 @@ class WordyCaseTest < Minitest::Test
   end
 
   def test_workload_with_expected_and_message
-    test_case = WordyCase.new(expected: 1, input: 'What is -3 plus 7 multiplied by -2?')
+    test_case = WordyCase.new(
+      case_data: {'expected' => 1, 'input' => 'What is -3 plus 7 multiplied by -2?'}
+    )
     message = test_case.send(:message)
 
     expected_workload = [
@@ -29,7 +31,7 @@ class WordyCaseTest < Minitest::Test
   end
 
   def test_workload_without_expected
-    test_case = WordyCase.new(input: 1)
+    test_case = WordyCase.new(case_data: {'input' => 1})
 
     expected_workload = [
       'question = \'1\'',

--- a/test/wordy_cases_test.rb
+++ b/test/wordy_cases_test.rb
@@ -4,7 +4,7 @@ require_relative '../exercises/wordy/.meta/generator/wordy_case'
 
 class WordyCaseTest < Minitest::Test
   def test_workload_with_expected_and_no_message
-    test_case = WordyCase.new(case_data: {'expected' => 1, 'input' => 1})
+    test_case = WordyCase.new(canonical: OpenStruct.new({'expected' => 1, 'input' => 1}))
 
     expected_workload = [
       'question = \'1\'',
@@ -16,7 +16,7 @@ class WordyCaseTest < Minitest::Test
 
   def test_workload_with_expected_and_message
     test_case = WordyCase.new(
-      case_data: {'expected' => 1, 'input' => 'What is -3 plus 7 multiplied by -2?'}
+      canonical: OpenStruct.new({'expected' => 1, 'input' => 'What is -3 plus 7 multiplied by -2?'})
     )
     message = test_case.send(:message)
 
@@ -31,7 +31,7 @@ class WordyCaseTest < Minitest::Test
   end
 
   def test_workload_without_expected
-    test_case = WordyCase.new(case_data: {'input' => 1})
+    test_case = WordyCase.new(canonical: OpenStruct.new({'input' => 1}))
 
     expected_workload = [
       'question = \'1\'',


### PR DESCRIPTION
> ExerciseCase should not be an OpenStruct and the canonical data should be kept separate from the methods of this class.

from Generator Improvements exercism/xruby#485.

Completes #622 to a usable state.

Outstanding issue: Update all the *_cases files to use the `canonical.` version.
These can easily be identified by emitting a warning whenever the forward method of ExerciseCase is called.
