### PR TITLE
[WIP] generator: refactor implementation, part 1

### DIFF
--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -15,7 +15,7 @@ module Generator
   # Doesn't update the version information.
   class GenerateTests < ImplementationDelegator
     def call
-      create_tests_file
+      build_tests
     end
   end
 
@@ -24,7 +24,7 @@ module Generator
     def call
       update_tests_version
       update_example_solution
-      create_tests_file
+      build_tests
     end
   end
 end

--- a/lib/generator/command_line.rb
+++ b/lib/generator/command_line.rb
@@ -16,7 +16,7 @@ module Generator
     attr_reader :paths
 
     def generators
-      implementations.map { |slug| generator(implementation(slug)) }
+      implementations.map { |slug| generator(implementation(exercise(slug))) }
     end
 
     def implementations
@@ -35,9 +35,13 @@ module Generator
       @options[:freeze] || @options[:all]
     end
 
-    def implementation(slug)
+    def exercise(slug)
+      Exercise.new(slug: slug)
+    end
+
+    def implementation(exercise)
       LoggingImplementation.new(
-        implementation: Implementation.new(paths: paths, slug: slug),
+        implementation: Implementation.new(paths: paths, exercise: exercise),
         logger: logger
       )
     end

--- a/lib/generator/exercise.rb
+++ b/lib/generator/exercise.rb
@@ -1,0 +1,19 @@
+module Generator
+  class Exercise
+    using Generator::Underscore
+
+    attr_reader :slug
+
+    def initialize(slug:)
+      @slug = slug
+    end
+
+    def name
+      @name ||= slug.underscore
+    end
+
+    def case_class
+      slug.camel_case + 'Case'
+    end
+  end
+end

--- a/lib/generator/files/generator_cases.rb
+++ b/lib/generator/files/generator_cases.rb
@@ -8,10 +8,6 @@ module Generator
           end.sort
         end
 
-        def class_name(exercise_name_or_slug)
-          filename(exercise_name_or_slug).split('_').map(&:capitalize).join
-        end
-
         def source_filepath(track_path, slug)
           path = meta_generator_path(track_path, slug)
           filename = filename(slug) + '.rb'

--- a/lib/generator/files/generator_cases.rb
+++ b/lib/generator/files/generator_cases.rb
@@ -3,7 +3,9 @@ module Generator
     module GeneratorCases
       class << self
         def available(track_path)
-          cases_filepaths(track_path).map { |filepath| slugify(filepath) }.sort
+          filepaths(track_path).map do |filepath|
+            %r{#{track_path}/exercises/([-a-z]+)/}.match(filepath)[1]
+          end.sort
         end
 
         def class_name(exercise_name_or_slug)
@@ -18,13 +20,8 @@ module Generator
 
         private
 
-        def cases_filepaths(track_path)
-          generator_glob = File.join(meta_generator_path(track_path, '*'), '*_case.rb')
-          Dir.glob(generator_glob, File::FNM_DOTMATCH)
-        end
-
-        def slugify(filepath)
-          File.basename(filepath, '_case.rb').tr('_', '-')
+        def filepaths(track_path)
+          Dir.glob(meta_generator_path(track_path, '*'))
         end
 
         def filename(exercise_name_or_slug)

--- a/lib/generator/files/metadata_files.rb
+++ b/lib/generator/files/metadata_files.rb
@@ -10,7 +10,7 @@ module Generator
       private
 
       def exercise_metadata_path
-        File.join(paths.metadata, 'exercises', slug)
+        File.join(paths.metadata, 'exercises', exercise.slug)
       end
     end
 

--- a/lib/generator/files/track_files.rb
+++ b/lib/generator/files/track_files.rb
@@ -22,7 +22,7 @@ module Generator
       private
 
       def exercise_path
-        File.join(paths.track, 'exercises', slug)
+        File.join(paths.track, 'exercises', exercise.slug)
       end
 
       def meta_path
@@ -34,7 +34,7 @@ module Generator
       end
 
       def minitest_tests_filename
-        "#{exercise_name}_test.rb"
+        "#{exercise.name}_test.rb"
       end
 
       def version_filename
@@ -42,7 +42,7 @@ module Generator
       end
 
       def example_filename
-        "#{exercise_name}.rb"
+        "#{exercise.name}.rb"
       end
 
       def tests_template_absolute_filename

--- a/lib/generator/implementation.rb
+++ b/lib/generator/implementation.rb
@@ -6,12 +6,12 @@ module Generator
     include Files::MetadataFiles
     include TemplateValuesFactory
 
-    def initialize(paths:, slug:)
+    def initialize(paths:, exercise:)
       @paths = paths
-      @slug = slug
+      @exercise = exercise
     end
 
-    attr_reader :paths, :slug
+    attr_reader :paths, :exercise
 
     def version
       tests_version.to_i
@@ -30,10 +30,6 @@ module Generator
         template: tests_template.to_s,
         values: template_values
       )
-    end
-
-    def exercise_name
-      @exercise_name ||= slug.tr('-', '_')
     end
   end
 
@@ -60,7 +56,7 @@ module Generator
 
     def create_tests_file
       @implementation.create_tests_file
-      @logger.info "Generated #{slug} tests version #{version}"
+      @logger.info "Generated #{exercise.slug} tests version #{version}"
     end
   end
 end

--- a/lib/generator/implementation.rb
+++ b/lib/generator/implementation.rb
@@ -25,7 +25,7 @@ module Generator
       example_solution.update_version(version)
     end
 
-    def create_tests_file
+    def build_tests
       minitest_tests.generate(
         template: tests_template.to_s,
         values: template_values
@@ -54,8 +54,8 @@ module Generator
       @logger.debug "Updated version in example solution to #{version}"
     end
 
-    def create_tests_file
-      @implementation.create_tests_file
+    def build_tests
+      @implementation.build_tests
       @logger.info "Generated #{exercise.slug} tests version #{version}"
     end
   end

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -26,16 +26,12 @@ module Generator
         abbreviated_commit_hash: canonical_data.abbreviated_commit_hash,
         canonical_data_version: canonical_data.version,
         version: version,
-        exercise_name: slug_underscore,
+        exercise_name: exercise.name,
         test_cases: extract
       )
     end
 
     private
-
-    def slug_underscore
-      slug ? slug.tr('-_', '_') : ''
-    end
 
     def extract
       load cases_load_name
@@ -43,13 +39,13 @@ module Generator
     end
 
     def extractor
-        CaseValues::Extractor.new(
-          case_class: Object.const_get(Files::GeneratorCases.class_name(slug))
-        )
+      CaseValues::Extractor.new(
+        case_class: Object.const_get(exercise.case_class)
+      )
     end
 
     def cases_load_name
-      Files::GeneratorCases.source_filepath(paths.track, slug)
+      Files::GeneratorCases.source_filepath(paths.track, exercise.slug)
     end
   end
 end

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -1,12 +1,14 @@
 module Generator
   # Contains methods accessible to the ERB template
   class TemplateValues
-    attr_reader :abbreviated_commit_hash, :version, :exercise_name, :test_cases, :canonical_data_version
+    using Underscore
 
-    def initialize(abbreviated_commit_hash:, version:, exercise_name:, test_cases:, canonical_data_version: nil)
+    attr_reader :abbreviated_commit_hash, :version, :exercise, :test_cases, :canonical_data_version
+
+    def initialize(abbreviated_commit_hash:, version:, exercise:, test_cases:, canonical_data_version: nil)
       @abbreviated_commit_hash = abbreviated_commit_hash
       @version = version
-      @exercise_name = exercise_name
+      @exercise = exercise
       @test_cases = test_cases
       @canonical_data_version = canonical_data_version
     end
@@ -15,8 +17,12 @@ module Generator
       binding
     end
 
+    def exercise_name
+      exercise.name
+    end
+
     def exercise_name_camel
-      exercise_name.split('_').map(&:capitalize).join
+      exercise.name.camel_case
     end
   end
 
@@ -26,7 +32,7 @@ module Generator
         abbreviated_commit_hash: canonical_data.abbreviated_commit_hash,
         canonical_data_version: canonical_data.version,
         version: version,
-        exercise_name: exercise.name,
+        exercise: exercise,
         test_cases: extract
       )
     end

--- a/lib/generator/template_values.rb
+++ b/lib/generator/template_values.rb
@@ -3,18 +3,25 @@ module Generator
   class TemplateValues
     using Underscore
 
-    attr_reader :abbreviated_commit_hash, :version, :exercise, :test_cases, :canonical_data_version
+    attr_reader :exercise, :version, :canonical_data, :test_cases
 
-    def initialize(abbreviated_commit_hash:, version:, exercise:, test_cases:, canonical_data_version: nil)
-      @abbreviated_commit_hash = abbreviated_commit_hash
-      @version = version
+    def initialize(exercise:, version:, canonical_data:, test_cases:)
       @exercise = exercise
+      @version = version
+      @canonical_data = canonical_data
       @test_cases = test_cases
-      @canonical_data_version = canonical_data_version
     end
 
     def get_binding
       binding
+    end
+
+    def abbreviated_commit_hash
+      canonical_data.abbreviated_commit_hash
+    end
+
+    def canonical_data_version
+      canonical_data.version
     end
 
     def exercise_name
@@ -29,10 +36,9 @@ module Generator
   module TemplateValuesFactory
     def template_values
       TemplateValues.new(
-        abbreviated_commit_hash: canonical_data.abbreviated_commit_hash,
-        canonical_data_version: canonical_data.version,
-        version: version,
         exercise: exercise,
+        version: version,
+        canonical_data: canonical_data,
         test_cases: extract
       )
     end

--- a/lib/generator/underscore.rb
+++ b/lib/generator/underscore.rb
@@ -4,6 +4,10 @@ module Generator
       def underscore
         downcase.gsub(/[- ]/, '_').gsub(/[^\w?]/, '')
       end
+
+      def camel_case
+        underscore.split('_').map(&:capitalize).join
+      end
     end
   end
 end

--- a/test/fixtures/xruby/lib/generator/test_template.erb
+++ b/test/fixtures/xruby/lib/generator/test_template.erb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 require 'minitest/autorun'
-require_relative 'acronym'
+require_relative '<%= exercise_name %>'
 
-# Common test data version: <%= abbreviated_commit_hash %>
-class AcronymTest < Minitest::Test
+# Common test data version: <%= canonical_data_version %> <%= abbreviated_commit_hash %>
+class <%= exercise_name_camel %>Test < Minitest::Test
 <% test_cases.each_with_index do |test_case, idx| %>
   def <%= test_case.name %>
     <%= test_case.skipped(idx) %>

--- a/test/generator/exercise_test.rb
+++ b/test/generator/exercise_test.rb
@@ -1,0 +1,20 @@
+require_relative '../test_helper'
+
+module Generator
+  class ExerciseTest < Minitest::Test
+    def test_slug
+      exercise = Exercise.new(slug: 'alpha')
+      assert_equal 'alpha', exercise.slug
+    end
+
+    def test_name
+      exercise = Exercise.new(slug: 'alpha-beta')
+      assert_equal 'alpha_beta', exercise.name
+    end
+
+    def test_case_class
+      exercise = Exercise.new(slug: 'alpha-beta')
+      assert_equal 'AlphaBetaCase', exercise.case_class
+    end
+  end
+end

--- a/test/generator/files/generate_cases_test.rb
+++ b/test/generator/files/generate_cases_test.rb
@@ -22,10 +22,6 @@ module Generator
         mock_glob_call.verify
       end
 
-      def test_class_name
-        assert_equal 'TwoParterCase', GeneratorCases.class_name('two-parter')
-      end
-
       def test_source_filepath
         track_path = '/track'
         slug = 'slug'

--- a/test/generator/files/generate_cases_test.rb
+++ b/test/generator/files/generate_cases_test.rb
@@ -5,17 +5,17 @@ module Generator
     class GeneratorCasesTest < Minitest::Test
       def test_available
         track_path = '/track'
-        fake_filenames = %w(/track/zzz/alpha_case.rb /track/aaa/hy_phen_ated_case.rb)
-        Dir.stub :glob, fake_filenames do
+        fake_filepaths = %w(/track/exercises/alpha/zzz /track/exercises/hy-phen-ated/yyy)
+        Dir.stub :glob, fake_filepaths do
           assert_equal %w(alpha hy-phen-ated), GeneratorCases.available(track_path)
         end
       end
 
       def test_available_calls_glob_with_the_right_arguments
         track_path = '/track'
-        expected_glob = "#{track_path}/exercises/*/.meta/generator/*_case.rb"
+        expected_glob = "#{track_path}/exercises/*/.meta/generator"
         mock_glob_call = Minitest::Mock.new
-        mock_glob_call.expect :call, [], [expected_glob, File::FNM_DOTMATCH]
+        mock_glob_call.expect :call, [], [expected_glob]
         Dir.stub :glob, mock_glob_call do
           GeneratorCases.available(track_path)
         end

--- a/test/generator/files/metadata_files_test.rb
+++ b/test/generator/files/metadata_files_test.rb
@@ -10,9 +10,9 @@ module Generator
       class TestMetadataFiles
         def initialize
           @paths = FixturePaths
-          @slug = 'alpha'
+          @exercise = Exercise.new(slug: 'alpha')
         end
-        attr_reader :paths, :slug
+        attr_reader :paths, :exercise
         include MetadataFiles
       end
 

--- a/test/generator/files/track_files_test.rb
+++ b/test/generator/files/track_files_test.rb
@@ -11,10 +11,9 @@ module Generator
       class TestTrackFiles
         def initialize
           @paths = FixturePaths
-          @slug = 'alpha-beta'
-          @exercise_name = 'alpha_beta'
+          @exercise = Exercise.new(slug: 'alpha-beta')
         end
-        attr_accessor :paths, :slug, :exercise_name
+        attr_reader :paths, :exercise
         include TrackFiles
       end
 
@@ -44,9 +43,9 @@ module Generator
       class TestTrackFilesUseDefault
         def initialize
           @paths = FixturePaths
-          @slug = 'notemplate'
+          @exercise = Exercise.new(slug: 'notemplate')
         end
-        attr_reader :paths, :slug
+        attr_reader :paths, :exercise
         include TrackFiles
       end
 

--- a/test/generator/implementation_test.rb
+++ b/test/generator/implementation_test.rb
@@ -8,13 +8,14 @@ module Generator
     )
 
     def test_version
-      subject = Implementation.new(paths: FixturePaths, slug: 'alpha')
+      exercise = Minitest::Mock.new.expect :slug, 'alpha'
+      subject = Implementation.new(paths: FixturePaths, exercise: exercise)
       assert_equal 1, subject.version
     end
 
     def test_update_tests_version
       mock_file = Minitest::Mock.new.expect :write, '2'.length, [2]
-      subject = Implementation.new(paths: FixturePaths, slug: 'alpha')
+      subject = Implementation.new(paths: FixturePaths, exercise: Exercise.new(slug: 'alpha'))
       # Verify iniital condition from fixture file
       assert_equal 1, subject.tests_version.to_i
       File.stub(:open, true, mock_file) do
@@ -26,7 +27,7 @@ module Generator
     def test_update_example_solution
       expected_content = "# This is the example\n\nclass BookKeeping\n  VERSION = 1\nend\n"
       mock_file = Minitest::Mock.new.expect :write, expected_content.length, [expected_content]
-      subject = Implementation.new(paths: FixturePaths, slug: 'alpha')
+      subject = Implementation.new(paths: FixturePaths, exercise: Exercise.new(slug: 'alpha'))
       File.stub(:open, true, mock_file) do
         assert_equal expected_content, subject.update_example_solution
       end
@@ -79,7 +80,7 @@ class AlphaTest < Minitest::Test
 end
 TESTS_FILE
       mock_file = Minitest::Mock.new.expect :write, expected_content.length, [expected_content]
-      subject = Implementation.new(paths: FixturePaths, slug: 'alpha')
+      subject = Implementation.new(paths: FixturePaths, exercise: Exercise.new(slug: 'alpha'))
       GitCommand.stub(:abbreviated_commit_hash, '123456789') do
         File.stub(:open, true, mock_file) do
           assert_equal expected_content, subject.create_tests_file
@@ -89,18 +90,14 @@ TESTS_FILE
       # Don't pollute the namespace
       Object.send(:remove_const, :AlphaCase)
     end
-
-    def test_exercise_name
-      subject = Implementation.new(paths: FixturePaths, slug: 'alpha-beta')
-      assert_equal 'alpha_beta', subject.exercise_name
-    end
   end
 
   class LoggingImplementationTest < Minitest::Test
     def test_create_tests_file
+      exercise = Exercise.new(slug: 'alpha')
       mock_implementation = Minitest::Mock.new
       mock_implementation.expect :create_tests_file, nil
-      mock_implementation.expect :slug, 'alpha'
+      mock_implementation.expect :exercise, exercise
       mock_implementation.expect :version, 2
       mock_logger = Minitest::Mock.new
       mock_logger.expect :info, nil, ['Generated alpha tests version 2']

--- a/test/generator/implementation_test.rb
+++ b/test/generator/implementation_test.rb
@@ -12,11 +12,6 @@ module Generator
       assert_equal 1, subject.version
     end
 
-    def test_slug
-      subject = Implementation.new(paths: FixturePaths, slug: 'alpha')
-      assert_equal 'alpha', subject.slug
-    end
-
     def test_update_tests_version
       mock_file = Minitest::Mock.new.expect :write, '2'.length, [2]
       subject = Implementation.new(paths: FixturePaths, slug: 'alpha')

--- a/test/generator/implementation_test.rb
+++ b/test/generator/implementation_test.rb
@@ -34,7 +34,7 @@ module Generator
       mock_file.verify
     end
 
-    def test_create_tests_file
+    def test_build_tests
       # Q: Is the pain here caused by:
       # a) Implementation `including` everything rather than using composition?
       # b) Trying to verify the expected content.
@@ -83,7 +83,7 @@ TESTS_FILE
       subject = Implementation.new(paths: FixturePaths, exercise: Exercise.new(slug: 'alpha'))
       GitCommand.stub(:abbreviated_commit_hash, '123456789') do
         File.stub(:open, true, mock_file) do
-          assert_equal expected_content, subject.create_tests_file
+          assert_equal expected_content, subject.build_tests
         end
       end
       mock_file.verify
@@ -93,17 +93,17 @@ TESTS_FILE
   end
 
   class LoggingImplementationTest < Minitest::Test
-    def test_create_tests_file
+    def test_build_tests
       exercise = Exercise.new(slug: 'alpha')
       mock_implementation = Minitest::Mock.new
-      mock_implementation.expect :create_tests_file, nil
+      mock_implementation.expect :build_tests, nil
       mock_implementation.expect :exercise, exercise
       mock_implementation.expect :version, 2
       mock_logger = Minitest::Mock.new
       mock_logger.expect :info, nil, ['Generated alpha tests version 2']
 
       subject = LoggingImplementation.new(implementation: mock_implementation, logger: mock_logger)
-      subject.create_tests_file
+      subject.build_tests
 
       mock_implementation.verify
     end

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -8,34 +8,10 @@ module Generator
       }
     end
 
-    def test_abbreviated_commit_hash
-      expected_abbreviated_commit_hash = '1234567'
-      subject = TemplateValues.new(@arguments.merge(abbreviated_commit_hash: expected_abbreviated_commit_hash))
-      assert_equal expected_abbreviated_commit_hash, subject.abbreviated_commit_hash
-    end
-
-    def test_version
-      expected_version = '1234567'
-      subject = TemplateValues.new(@arguments.merge(version: expected_version))
-      assert_equal expected_version, subject.version
-    end
-
-    def test_exercise_name
-      expected_exercise_name = 'alpha_beta'
-      subject = TemplateValues.new(@arguments.merge(exercise_name: expected_exercise_name))
-      assert_equal expected_exercise_name, subject.exercise_name
-    end
-
     def test_exercise_name_camel
       expected_exercise_name_camel = 'AlphaBeta'
       subject = TemplateValues.new(@arguments.merge(exercise_name: 'alpha_beta'))
       assert_equal expected_exercise_name_camel, subject.exercise_name_camel
-    end
-
-    def test_test_cases
-      expected_test_cases = 'should be TemplateValues class'
-      subject = TemplateValues.new(@arguments.merge(test_cases: expected_test_cases))
-      assert_equal expected_test_cases, subject.test_cases
     end
 
     def test_get_binding

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -4,8 +4,22 @@ module Generator
   class TestTemplateValuesTest < Minitest::Test
     def setup
       @arguments = {
-        abbreviated_commit_hash: nil, version: nil, exercise: nil, test_cases: nil
+        exercise: nil, version: nil, canonical_data: nil, test_cases: nil
       }
+    end
+
+    def test_abbreviated_commit_hash
+      expected_abbreviated_commit_hash = '1234567'
+      mock_canonical_data = Minitest::Mock.new.expect :abbreviated_commit_hash, expected_abbreviated_commit_hash
+      subject = TemplateValues.new(@arguments.merge(canonical_data: mock_canonical_data))
+      assert_equal expected_abbreviated_commit_hash, subject.abbreviated_commit_hash
+    end
+
+    def test_canonical_data_version
+      expected_canonical_data_version = '0.1.0'
+      mock_canonical_data = Minitest::Mock.new.expect :version, expected_canonical_data_version
+      subject = TemplateValues.new(@arguments.merge(canonical_data: mock_canonical_data))
+      assert_equal expected_canonical_data_version, subject.canonical_data_version
     end
 
     def test_exercise_name

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -71,17 +71,6 @@ module Generator
       include TemplateValuesFactory
     end
 
-    class ClassBasedTestTemplateValuesFactory < TestTemplateValuesFactory
-      def slug
-        Exercise.new(slug: 'beta')
-      end
-    end
-
-    def test_template_values_from_class
-      subject = ClassBasedTestTemplateValuesFactory.new
-      assert_instance_of TemplateValues, subject.template_values
-    end
-
     def test_template_values_loads_problem_case_classes
       subject = TestTemplateValuesFactory.new
       assert_instance_of TemplateValues, subject.template_values

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -46,8 +46,8 @@ module Generator
 
   class TemplateValuesFactoryTest < Minitest::Test
     class TestTemplateValuesFactory
-      def slug
-        'alpha'
+      def exercise
+        Exercise.new(slug: 'alpha')
       end
 
       def version
@@ -71,30 +71,10 @@ module Generator
       include TemplateValuesFactory
     end
 
-    class ClassBasedTestTemplateValuesFactory
+    class ClassBasedTestTemplateValuesFactory < TestTemplateValuesFactory
       def slug
-        'beta'
+        Exercise.new(slug: 'beta')
       end
-
-      def version
-        2
-      end
-
-      def canonical_data
-        mock_canonical_data = Minitest::Mock.new
-        mock_canonical_data.expect :abbreviated_commit_hash, nil
-        mock_canonical_data.expect :version, '1.2.3'
-        mock_canonical_data.expect :to_s, '{"cases":[]}'
-        mock_canonical_data
-      end
-
-      def paths
-        mock_paths = Minitest::Mock.new
-        mock_paths.expect :track, 'test/fixtures/xruby'
-        mock_paths
-      end
-
-      include TemplateValuesFactory
     end
 
     def test_template_values_from_class

--- a/test/generator/template_values_test.rb
+++ b/test/generator/template_values_test.rb
@@ -4,13 +4,19 @@ module Generator
   class TestTemplateValuesTest < Minitest::Test
     def setup
       @arguments = {
-        abbreviated_commit_hash: nil, version: nil, exercise_name: nil, test_cases: nil
+        abbreviated_commit_hash: nil, version: nil, exercise: nil, test_cases: nil
       }
+    end
+
+    def test_exercise_name
+      expected_exercise_name = 'alpha_beta'
+      subject = TemplateValues.new(@arguments.merge(exercise: Exercise.new(slug: 'alpha-beta')))
+      assert_equal expected_exercise_name, subject.exercise_name
     end
 
     def test_exercise_name_camel
       expected_exercise_name_camel = 'AlphaBeta'
-      subject = TemplateValues.new(@arguments.merge(exercise_name: 'alpha_beta'))
+      subject = TemplateValues.new(@arguments.merge(exercise: Exercise.new(slug: 'alpha_beta')))
       assert_equal expected_exercise_name_camel, subject.exercise_name_camel
     end
 

--- a/test/generator/underscore_test.rb
+++ b/test/generator/underscore_test.rb
@@ -19,5 +19,9 @@ module Generator
         'unreadable_but_correctly_sized_inputs_return_?'
       )
     end
+
+    def test_camel_case
+      assert_equal 'ASlug', 'a-slug'.camel_case
+    end
   end
 end

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -6,7 +6,7 @@ module Generator
       mock_exercise = Minitest::Mock.new
       mock_exercise.expect :update_tests_version, nil
       mock_exercise.expect :update_example_solution, nil
-      mock_exercise.expect :create_tests_file, nil
+      mock_exercise.expect :build_tests, nil
 
       subject = UpdateVersionAndGenerateTests.new(mock_exercise)
       subject.call
@@ -18,7 +18,7 @@ module Generator
   class UpdateVersionAndGenerateTestsFrozenVersionTest < Minitest::Test
     def test_call
       mock_exercise = Minitest::Mock.new
-      mock_exercise.expect :create_tests_file, nil
+      mock_exercise.expect :build_tests, nil
 
       subject = GenerateTests.new(mock_exercise)
       subject.call


### PR DESCRIPTION
I did this PR in two parts. The first part (this one) separates out the Exercise model.

The second part (two different PRs) separates out the Repository model in two different ways. One PR creates a Repository which is instantiated with paths only. The second PR creates a Repository which is instantiated with paths and exercise.