### PR TITLE
Be more helpful when generator can not be found

### DIFF
--- a/lib/generator/command_line/generator_optparser.rb
+++ b/lib/generator/command_line/generator_optparser.rb
@@ -83,9 +83,9 @@ module Generator
 
     def validate_cases
       return true if available_generators.include?(options[:slug])
-      error_message = "A generator does not currently exist for #{options[:slug]}!"
+      warning = "A generator does not currently exist for #{options[:slug]}!"
       expected_locations = "Expecting it to be at: #{Files::GeneratorCases.source_filepath(@paths.track, options[:slug])}"
-      $stderr.puts [error_message, expected_locations].join("\n")
+      $stderr.puts [warning, expected_locations].join("\n")
       false
     end
   end

--- a/lib/generator/command_line/generator_optparser.rb
+++ b/lib/generator/command_line/generator_optparser.rb
@@ -83,7 +83,9 @@ module Generator
 
     def validate_cases
       return true if available_generators.include?(options[:slug])
-      $stderr.puts "A generator does not currently exist for #{options[:slug]}!"
+      error_message = "A generator does not currently exist for #{options[:slug]}!"
+      expected_locations = "Expecting it to be at: #{Files::GeneratorCases.source_filepath(@paths.track, options[:slug])}"
+      $stderr.puts [error_message, expected_locations].join("\n")
       false
     end
   end

--- a/lib/generator/command_line/generator_optparser.rb
+++ b/lib/generator/command_line/generator_optparser.rb
@@ -84,8 +84,8 @@ module Generator
     def validate_cases
       return true if available_generators.include?(options[:slug])
       warning = "A generator does not currently exist for #{options[:slug]}!"
-      expected_locations = "Expecting it to be at: #{Files::GeneratorCases.source_filepath(@paths.track, options[:slug])}"
-      $stderr.puts [warning, expected_locations].join("\n")
+      expected_location = "Expecting it to be at: #{Files::GeneratorCases.source_filepath(@paths.track, options[:slug])}"
+      $stderr.puts [warning, expected_location].join("\n")
       false
     end
   end

--- a/test/generator/command_line/generator_optparser_test.rb
+++ b/test/generator/command_line/generator_optparser_test.rb
@@ -111,9 +111,9 @@ module Generator
     end
 
     def test_validate_missing_generator
-      args = %w(nonexistent)
+      args = %w(non-existent)
       Files::GeneratorCases.stub :available, [] do
-        assert_output(nil, /A generator does not currently exist fo/) do
+        assert_output(nil, /A generator does not currently exist for non-existent/) do
           refute GeneratorOptparser.new(args, FixturePaths).options_valid?
         end
       end

--- a/test/generator/command_line/generator_optparser_test.rb
+++ b/test/generator/command_line/generator_optparser_test.rb
@@ -118,5 +118,14 @@ module Generator
         end
       end
     end
+
+    def test_missing_generator_tells_you_where_it_looked
+      args = %w(non-existent)
+      Files::GeneratorCases.stub :available, [] do
+        assert_output(nil, %r{exercises/non-existent/\.meta/generator/non_existent_case\.rb}) do
+          refute GeneratorOptparser.new(args, FixturePaths).options_valid?
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves #644 

In #583 there was a problem with the generator not being found:

```
$ bin/generate space-age
A generator does not currently exist for space-age!
```

This patch adds a bit more information to the error message about where the generator expected to find the file it needs.

```
A generator does not currently exist for space-age!
Expecting it to be at: <user_specific_path>/exercises/space-age/.meta/generator/space_age_case.rb
```
