### PR TITLE
Add missing skip in trinary_test

### DIFF
--- a/exercises/trinary/trinary_test.rb
+++ b/exercises/trinary/trinary_test.rb
@@ -78,6 +78,7 @@ class TrinaryTest < Minitest::Test
   # If you are curious, read more about constants on RubyDoc:
   # http://ruby-doc.org/docs/ruby-doc-bundle/UsersGuide/rg/constants.htm
   def test_bookkeeping
+    skip
     assert_equal 1, BookKeeping::VERSION
   end
 end


### PR DESCRIPTION
I noticed that the trinary test didn't automatically skip the book keeping test.

This pull request fixes that.