### PR TITLE
Add the "first patch" labels to exempt from stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,6 +8,8 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
+  - good first patch
+  - first-timers only
 # Label to use when marking as stale
 staleLabel: stale
 # Comment to post when marking as stale. Set to `false` to disable


### PR DESCRIPTION
@tejasbuane had the idea of keeping the these accepted work units to be
kept from becoming stale.
