### PR TITLE
Provide parameters in test failure message for Triangle exercise

### DIFF
--- a/exercises/triangle/.meta/generator/triangle_case.rb
+++ b/exercises/triangle/.meta/generator/triangle_case.rb
@@ -28,7 +28,7 @@ class TriangleCase < Generator::ExerciseCase
   end
 
   def expected_type
-    "triangle is #{expected ? '' : 'not '}#{property}"
+    "triangle #{sides} is #{expected ? '' : 'not '}#{property}"
   end
 
 end

--- a/exercises/triangle/.meta/generator/triangle_case.rb
+++ b/exercises/triangle/.meta/generator/triangle_case.rb
@@ -24,11 +24,19 @@ class TriangleCase < Generator::ExerciseCase
   end
 
   def failure_message
-    %Q("Expected '#{expected}', #{expected_type}.")
+    %Q("Expected '#{expected}', #{expected_triangle}.")
   end
 
   def expected_type
-    "triangle #{sides} is #{expected ? '' : 'not '}#{property}"
+    "triangle is #{type}"
+  end
+
+  def expected_triangle
+    "triangle #{sides} is #{type}"
+  end
+
+  def type
+    "#{expected ? '' : 'not ' }#{property}"
   end
 
 end

--- a/exercises/triangle/triangle_test.rb
+++ b/exercises/triangle/triangle_test.rb
@@ -7,103 +7,103 @@ class TriangleTest < Minitest::Test
   def test_triangle_is_equilateral_if_all_sides_are_equal
     # skip
     triangle = Triangle.new([2, 2, 2])
-    assert triangle.equilateral?, "Expected 'true', triangle is equilateral."
+    assert triangle.equilateral?, "Expected 'true', triangle [2, 2, 2] is equilateral."
   end
 
   def test_triangle_is_not_equilateral_if_any_side_is_unequal
     skip
     triangle = Triangle.new([2, 3, 2])
-    refute triangle.equilateral?, "Expected 'false', triangle is not equilateral."
+    refute triangle.equilateral?, "Expected 'false', triangle [2, 3, 2] is not equilateral."
   end
 
   def test_triangle_is_not_equilateral_if_no_sides_are_equal
     skip
     triangle = Triangle.new([5, 4, 6])
-    refute triangle.equilateral?, "Expected 'false', triangle is not equilateral."
+    refute triangle.equilateral?, "Expected 'false', triangle [5, 4, 6] is not equilateral."
   end
 
   def test_all_zero_sides_are_illegal_so_the_triangle_is_not_equilateral
     skip
     triangle = Triangle.new([0, 0, 0])
-    refute triangle.equilateral?, "Expected 'false', triangle is not equilateral."
+    refute triangle.equilateral?, "Expected 'false', triangle [0, 0, 0] is not equilateral."
   end
 
   def test_equilateral_triangle_sides_may_be_floats
     skip
     triangle = Triangle.new([0.5, 0.5, 0.5])
-    assert triangle.equilateral?, "Expected 'true', triangle is equilateral."
+    assert triangle.equilateral?, "Expected 'true', triangle [0.5, 0.5, 0.5] is equilateral."
   end
 
   def test_triangle_is_isosceles_if_last_two_sides_are_equal
     skip
     triangle = Triangle.new([3, 4, 4])
-    assert triangle.isosceles?, "Expected 'true', triangle is isosceles."
+    assert triangle.isosceles?, "Expected 'true', triangle [3, 4, 4] is isosceles."
   end
 
   def test_triangle_is_isosceles_if_first_two_sides_are_equal
     skip
     triangle = Triangle.new([4, 4, 3])
-    assert triangle.isosceles?, "Expected 'true', triangle is isosceles."
+    assert triangle.isosceles?, "Expected 'true', triangle is [4, 4, 3] isosceles."
   end
 
   def test_triangle_is_isosceles_if_first_and_last_sides_are_equal
     skip
     triangle = Triangle.new([4, 3, 4])
-    assert triangle.isosceles?, "Expected 'true', triangle is isosceles."
+    assert triangle.isosceles?, "Expected 'true', triangle [4, 3, 4] is isosceles."
   end
 
   def test_equilateral_triangles_are_also_isosceles
     skip
     triangle = Triangle.new([4, 4, 4])
-    assert triangle.isosceles?, "Expected 'true', triangle is isosceles."
+    assert triangle.isosceles?, "Expected 'true', triangle [4, 4, 4] is isosceles."
   end
 
   def test_triangle_is_not_isosceles_if_no_sides_are_equal
     skip
     triangle = Triangle.new([2, 3, 4])
-    refute triangle.isosceles?, "Expected 'false', triangle is not isosceles."
+    refute triangle.isosceles?, "Expected 'false', triangle [2, 3, 4] is not isosceles."
   end
 
   def test_sides_that_violate_triangle_inequality_are_not_isosceles_even_if_two_are_equal
     skip
     triangle = Triangle.new([1, 1, 3])
-    refute triangle.isosceles?, "Expected 'false', triangle is not isosceles."
+    refute triangle.isosceles?, "Expected 'false', triangle [1, 1, 3] is not isosceles."
   end
 
   def test_isosceles_triangle_sides_may_be_floats
     skip
     triangle = Triangle.new([0.5, 0.4, 0.5])
-    assert triangle.isosceles?, "Expected 'true', triangle is isosceles."
+    assert triangle.isosceles?, "Expected 'true', triangle [0.5, 0.4, 0.5] is isosceles."
   end
 
   def test_triangle_is_scalene_if_no_sides_are_equal
     skip
     triangle = Triangle.new([5, 4, 6])
-    assert triangle.scalene?, "Expected 'true', triangle is scalene."
+    assert triangle.scalene?, "Expected 'true', triangle [5, 4, 6] is scalene."
   end
 
   def test_triangle_is_not_scalene_if_all_sides_are_equal
     skip
     triangle = Triangle.new([4, 4, 4])
-    refute triangle.scalene?, "Expected 'false', triangle is not scalene."
+    refute triangle.scalene?, "Expected 'false', triangle [4, 4, 4] is not scalene."
   end
 
   def test_triangle_is_not_scalene_if_two_sides_are_equal
     skip
     triangle = Triangle.new([4, 4, 3])
-    refute triangle.scalene?, "Expected 'false', triangle is not scalene."
+    refute triangle.scalene?, "Expected 'false', triangle [4, 4, 3] is not scalene."
   end
 
   def test_sides_that_violate_triangle_inequality_are_not_scalene_even_if_they_are_all_different
     skip
     triangle = Triangle.new([7, 3, 2])
-    refute triangle.scalene?, "Expected 'false', triangle is not scalene."
+    refute triangle.scalene?, "Expected 'false', triangle [7, 3, 2] is not scalene."
   end
 
   def test_scalene_triangle_sides_may_be_floats
     skip
     triangle = Triangle.new([0.5, 0.4, 0.6])
-    assert triangle.scalene?, "Expected 'true', triangle is scalene."
+    assert triangle.scalene?, "Expected 'true', triangle [0.5, 0.4, 0.6] is scalene."
   end
 
   # Problems in exercism evolve over time, as we find better ways to ask

--- a/exercises/triangle/triangle_test.rb
+++ b/exercises/triangle/triangle_test.rb
@@ -4,19 +4,19 @@ require_relative 'triangle'
 
 # Common test data version: 1.0.0 fa90b35
 class TriangleTest < Minitest::Test
-  def test_triangle_is_equilateral_if_all_sides_are_equal
+  def test_triangle_[2_2_2]_is_equilateral_if_all_sides_are_equal
     # skip
     triangle = Triangle.new([2, 2, 2])
     assert triangle.equilateral?, "Expected 'true', triangle [2, 2, 2] is equilateral."
   end
 
-  def test_triangle_is_not_equilateral_if_any_side_is_unequal
+  def test_triangle_[2_3_2]_is_not_equilateral_if_any_side_is_unequal
     skip
     triangle = Triangle.new([2, 3, 2])
     refute triangle.equilateral?, "Expected 'false', triangle [2, 3, 2] is not equilateral."
   end
 
-  def test_triangle_is_not_equilateral_if_no_sides_are_equal
+  def test_triangle_[5_4_6]_is_not_equilateral_if_no_sides_are_equal
     skip
     triangle = Triangle.new([5, 4, 6])
     refute triangle.equilateral?, "Expected 'false', triangle [5, 4, 6] is not equilateral."
@@ -34,19 +34,19 @@ class TriangleTest < Minitest::Test
     assert triangle.equilateral?, "Expected 'true', triangle [0.5, 0.5, 0.5] is equilateral."
   end
 
-  def test_triangle_is_isosceles_if_last_two_sides_are_equal
+  def test_triangle_[3_4_4]_is_isosceles_if_last_two_sides_are_equal
     skip
     triangle = Triangle.new([3, 4, 4])
     assert triangle.isosceles?, "Expected 'true', triangle [3, 4, 4] is isosceles."
   end
 
-  def test_triangle_is_isosceles_if_first_two_sides_are_equal
+  def test_triangle_[4_4_3]_is_isosceles_if_first_two_sides_are_equal
     skip
     triangle = Triangle.new([4, 4, 3])
     assert triangle.isosceles?, "Expected 'true', triangle [4, 4, 3] is isosceles."
   end
 
-  def test_triangle_is_isosceles_if_first_and_last_sides_are_equal
+  def test_triangle_[4_3_4]_is_isosceles_if_first_and_last_sides_are_equal
     skip
     triangle = Triangle.new([4, 3, 4])
     assert triangle.isosceles?, "Expected 'true', triangle [4, 3, 4] is isosceles."
@@ -58,7 +58,7 @@ class TriangleTest < Minitest::Test
     assert triangle.isosceles?, "Expected 'true', triangle [4, 4, 4] is isosceles."
   end
 
-  def test_triangle_is_not_isosceles_if_no_sides_are_equal
+  def test_triangle_[2_3_4]_is_not_isosceles_if_no_sides_are_equal
     skip
     triangle = Triangle.new([2, 3, 4])
     refute triangle.isosceles?, "Expected 'false', triangle [2, 3, 4] is not isosceles."
@@ -76,19 +76,19 @@ class TriangleTest < Minitest::Test
     assert triangle.isosceles?, "Expected 'true', triangle [0.5, 0.4, 0.5] is isosceles."
   end
 
-  def test_triangle_is_scalene_if_no_sides_are_equal
+  def test_triangle_[5_4_6]_is_scalene_if_no_sides_are_equal
     skip
     triangle = Triangle.new([5, 4, 6])
     assert triangle.scalene?, "Expected 'true', triangle [5, 4, 6] is scalene."
   end
 
-  def test_triangle_is_not_scalene_if_all_sides_are_equal
+  def test_triangle_[4_4_4]_is_not_scalene_if_all_sides_are_equal
     skip
     triangle = Triangle.new([4, 4, 4])
     refute triangle.scalene?, "Expected 'false', triangle [4, 4, 4] is not scalene."
   end
 
-  def test_triangle_is_not_scalene_if_two_sides_are_equal
+  def test_triangle_[4_4_3]_is_not_scalene_if_two_sides_are_equal
     skip
     triangle = Triangle.new([4, 4, 3])
     refute triangle.scalene?, "Expected 'false', triangle [4, 4, 3] is not scalene."

--- a/exercises/triangle/triangle_test.rb
+++ b/exercises/triangle/triangle_test.rb
@@ -43,7 +43,7 @@ class TriangleTest < Minitest::Test
   def test_triangle_is_isosceles_if_first_two_sides_are_equal
     skip
     triangle = Triangle.new([4, 4, 3])
-    assert triangle.isosceles?, "Expected 'true', triangle is [4, 4, 3] isosceles."
+    assert triangle.isosceles?, "Expected 'true', triangle [4, 4, 3] is isosceles."
   end
 
   def test_triangle_is_isosceles_if_first_and_last_sides_are_equal

--- a/exercises/triangle/triangle_test.rb
+++ b/exercises/triangle/triangle_test.rb
@@ -4,19 +4,19 @@ require_relative 'triangle'
 
 # Common test data version: 1.0.0 fa90b35
 class TriangleTest < Minitest::Test
-  def test_triangle_[2_2_2]_is_equilateral_if_all_sides_are_equal
+  def test_triangle_is_equilateral_if_all_sides_are_equal
     # skip
     triangle = Triangle.new([2, 2, 2])
     assert triangle.equilateral?, "Expected 'true', triangle [2, 2, 2] is equilateral."
   end
 
-  def test_triangle_[2_3_2]_is_not_equilateral_if_any_side_is_unequal
+  def test_triangle_is_not_equilateral_if_any_side_is_unequal
     skip
     triangle = Triangle.new([2, 3, 2])
     refute triangle.equilateral?, "Expected 'false', triangle [2, 3, 2] is not equilateral."
   end
 
-  def test_triangle_[5_4_6]_is_not_equilateral_if_no_sides_are_equal
+  def test_triangle_is_not_equilateral_if_no_sides_are_equal
     skip
     triangle = Triangle.new([5, 4, 6])
     refute triangle.equilateral?, "Expected 'false', triangle [5, 4, 6] is not equilateral."
@@ -34,19 +34,19 @@ class TriangleTest < Minitest::Test
     assert triangle.equilateral?, "Expected 'true', triangle [0.5, 0.5, 0.5] is equilateral."
   end
 
-  def test_triangle_[3_4_4]_is_isosceles_if_last_two_sides_are_equal
+  def test_triangle_is_isosceles_if_last_two_sides_are_equal
     skip
     triangle = Triangle.new([3, 4, 4])
     assert triangle.isosceles?, "Expected 'true', triangle [3, 4, 4] is isosceles."
   end
 
-  def test_triangle_[4_4_3]_is_isosceles_if_first_two_sides_are_equal
+  def test_triangle_is_isosceles_if_first_two_sides_are_equal
     skip
     triangle = Triangle.new([4, 4, 3])
     assert triangle.isosceles?, "Expected 'true', triangle [4, 4, 3] is isosceles."
   end
 
-  def test_triangle_[4_3_4]_is_isosceles_if_first_and_last_sides_are_equal
+  def test_triangle_is_isosceles_if_first_and_last_sides_are_equal
     skip
     triangle = Triangle.new([4, 3, 4])
     assert triangle.isosceles?, "Expected 'true', triangle [4, 3, 4] is isosceles."
@@ -58,7 +58,7 @@ class TriangleTest < Minitest::Test
     assert triangle.isosceles?, "Expected 'true', triangle [4, 4, 4] is isosceles."
   end
 
-  def test_triangle_[2_3_4]_is_not_isosceles_if_no_sides_are_equal
+  def test_triangle_is_not_isosceles_if_no_sides_are_equal
     skip
     triangle = Triangle.new([2, 3, 4])
     refute triangle.isosceles?, "Expected 'false', triangle [2, 3, 4] is not isosceles."
@@ -76,19 +76,19 @@ class TriangleTest < Minitest::Test
     assert triangle.isosceles?, "Expected 'true', triangle [0.5, 0.4, 0.5] is isosceles."
   end
 
-  def test_triangle_[5_4_6]_is_scalene_if_no_sides_are_equal
+  def test_triangle_is_scalene_if_no_sides_are_equal
     skip
     triangle = Triangle.new([5, 4, 6])
     assert triangle.scalene?, "Expected 'true', triangle [5, 4, 6] is scalene."
   end
 
-  def test_triangle_[4_4_4]_is_not_scalene_if_all_sides_are_equal
+  def test_triangle_is_not_scalene_if_all_sides_are_equal
     skip
     triangle = Triangle.new([4, 4, 4])
     refute triangle.scalene?, "Expected 'false', triangle [4, 4, 4] is not scalene."
   end
 
-  def test_triangle_[4_4_3]_is_not_scalene_if_two_sides_are_equal
+  def test_triangle_is_not_scalene_if_two_sides_are_equal
     skip
     triangle = Triangle.new([4, 4, 3])
     refute triangle.scalene?, "Expected 'false', triangle [4, 4, 3] is not scalene."


### PR DESCRIPTION
<!--- This template is meant to help develop good habits in creating PRs. -->
<!--- Feel free to delete it if you don't find it useful. -->

<!--- Provide a general summary of your changes in the Title above -->

## Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To make it possible to see from the failure message which triangle is being tested/failing.  #653 

## What?
<!--- Describe your changes in detail -->
Provided the parameters that are being tested in the error message for a more informative message. 
So instead of:
```
  1) Failure:
TriangleTest#test_equilateral_triangle_sides_may_be_floats [ruby/triangle/triangle_test.rb:36]:
Expected 'true', triangle is equilateral.
```
You would see:
```
Expected 'true', triangle [0.5, 0.5, 0.5] is equilateral.
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created a Triangle class that would fail the tests to produce the errors. Please see the screen shot below for the outputs. 

## Screenshots (if appropriate):
<img width="1233" alt="screen shot 2017-05-28 at 10 41 33 am" src="https://cloud.githubusercontent.com/assets/10988491/26530880/c480e67e-4392-11e7-96be-b903c68c9a61.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- n/a Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- n/a Breaking change (fix or enhancement that would cause existing functionality to change)
- n/a Gardening (code and/or documentation cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My change relies on a pending issue/pull request
- n/a My change requires a change to the documentation.
- n/a I have updated the documentation accordingly.
- n/a I have added tests to cover my changes.
- [x] All new and existing tests passed.

Edit: removed empty checkboxes.