### PR TITLE
Update Generated Test Suites section in README with gem documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ rake test:clock -- -p
 ```
 
 To run a subset of the tests, use a regular expression. For example, if tests
-exist taht are named identical_to_4_places, and identical, then we can run both
+exist that are named identical_to_4_places, and identical, then we can run both
 tests with
 
 ```sh
@@ -70,6 +70,9 @@ Note that flags which have an attached value, like above, must take the form
 ### Generated Test Suites
 
 Generated test suites use the `bin/generator` cli.
+
+Before using the cli it is recommended you run `bundle install` from within
+the xruby directory to install/update any required gems.
 
 While many of the exercises which have canonical data already have generators,
 some do not. To find out whether an exercise has a generator, run


### PR DESCRIPTION
<!--- This template is meant to help develop good habits in creating PRs. -->
<!--- Feel free to delete it if you don't find it useful. -->

<!--- Provide a general summary of your changes in the Title above -->

## Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When I was trying to regenerate the test suites I was getting the error: 
```
/Users/alexanderdelgado/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- require_all (LoadError)
    from /Users/alexanderdelgado/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/alexanderdelgado/Developer/open-source/xruby/lib/generator.rb:1:in `<top (required)>'
    from /Users/alexanderdelgado/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/alexanderdelgado/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from bin/generate:4:in `<main>'
```
@Insti let me know that it was because I needed the `require_all` gem and I just needed to run
`bundle install` 

Adding this to the documentation would help others regenerate the test suites successfully in the future. 

## What?
<!--- Describe your changes in detail -->
Just added the instructions under the Generating Test Suites section. 
Also fixed a quick typo in the documentation. 

## Screenshots (if appropriate):
<img width="931" alt="screen shot 2017-05-29 at 10 25 37 pm" src="https://cloud.githubusercontent.com/assets/10988491/26569268/61f76000-44be-11e7-8594-06ab342dcac6.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or enhancement that would cause existing functionality to change)
- [x] Gardening (code and/or documentation cleanup)

## References and Closures
<!--- not previously mentioned -->
<!--- references #000 -->
<!--- closes #000 -->
Closes #661 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change relies on a pending issue/pull request
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Notes
Let me know if you'd like to see it explained differently or added to another part of the documentation!
