### PR TITLE
Test no longer supplies the `date` dependency for solution

### DIFF
--- a/exercises/meetup/.meta/solutions/meetup.rb
+++ b/exercises/meetup/.meta/solutions/meetup.rb
@@ -1,3 +1,4 @@
+require 'date'
 class Meetup
   def self.days_of_week
     [:sunday, :monday, :tuesday, :wednesday, :thursday, :friday, :saturday]

--- a/exercises/meetup/meetup_test.rb
+++ b/exercises/meetup/meetup_test.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 require 'minitest/autorun'
-require 'date'
 require_relative 'meetup'
 
 # Define a class Meetup with a constructor taking a month and a year


### PR DESCRIPTION
<!--- This template is meant to help develop good habits in creating PRs. -->
<!--- Feel free to delete it if you don't find it useful. -->

<!--- Provide a general summary of your changes in the Title above -->

## Why?
Test was supplying the 'date' library, but shouldn't.

## What?
Date requirement is now in the example solution.
